### PR TITLE
feat: split CI jobs

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,58 @@
+name: Build Android
+
+on: workflow_call
+
+jobs:
+  build-android:
+      runs-on: ubuntu-latest
+      env:
+        TURBO_CACHE_DIR: .turbo/android
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup
+          uses: ./.github/actions/setup
+
+        - name: Cache turborepo for Android
+          uses: actions/cache@v4
+          with:
+            path: ${{ env.TURBO_CACHE_DIR }}
+            key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-turborepo-android-
+
+        - name: Check turborepo cache for Android
+          run: |
+            TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:android').cache.status")
+
+            if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
+              echo "turbo_cache_hit=1" >> $GITHUB_ENV
+            fi
+
+        - name: Install JDK
+          if: env.turbo_cache_hit != 1
+          uses: actions/setup-java@v3
+          with:
+            distribution: 'zulu'
+            java-version: '17'
+
+        - name: Finalize Android SDK
+          if: env.turbo_cache_hit != 1
+          run: |
+            /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
+
+        - name: Cache Gradle
+          if: env.turbo_cache_hit != 1
+          uses: actions/cache@v4
+          with:
+            path: |
+              ~/.gradle/wrapper
+              ~/.gradle/caches
+            key: ${{ runner.os }}-gradle-${{ hashFiles('example/android/gradle/wrapper/gradle-wrapper.properties') }}
+            restore-keys: |
+              ${{ runner.os }}-gradle-
+
+        - name: Build example for Android
+          run: |
+            yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,59 @@
+name: Build iOS
+
+on:
+  workflow_call:
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    env:
+      TURBO_CACHE_DIR: .turbo/ios
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.4"  
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Cache turborepo for iOS
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TURBO_CACHE_DIR }}
+          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turborepo-ios-
+
+      - name: Check turborepo cache for iOS
+        run: |
+          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
+
+          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
+            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+          fi
+
+      - name: Cache cocoapods
+        if: env.turbo_cache_hit != 1
+        id: cocoapods-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/ios/Pods
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cocoapods-
+
+      - name: Install cocoapods
+        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
+        run: |
+          yarn pod-install example/ios
+        env:
+          NO_FLIPPER: 1
+
+      - name: Build example for iOS
+        run: |
+          yarn turbo build:ios --cache-dir="{{ env.TURBO_CACHE_DIR }}"

--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -1,0 +1,17 @@
+name: Build Library
+
+on:
+  workflow_call:
+
+jobs:
+  build-library:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup
+          uses: ./.github/actions/setup
+
+        - name: Build package
+          run: yarn prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     uses: ./.github/workflows/lint.yml
 
   test:
-    uses: ./.github/workflows/test.yml
+    uses: ./.github/workflows/tests.yml
 
   build-library:
-    uses: ./.github/workflows/build_library.yml
+    uses: ./.github/workflows/build-library.yml
 
   build-android:
-    uses: ./.github/workflows/build_android.yml
+    uses: ./.github/workflows/build-android.yml
 
   build-ios:
-    uses: ./.github/workflows/build_ios.yml
+    uses: ./.github/workflows/build-ios.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,148 +9,16 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Lint files
-        run: yarn lint
-
-      - name: Typecheck files
-        run: yarn typecheck
+    uses: ./.github/workflows/lint.yml
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run unit tests
-        run: yarn test --maxWorkers=2 --coverage
+    uses: ./.github/workflows/test.yml
 
   build-library:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Build package
-        run: yarn prepare
+    uses: ./.github/workflows/build_library.yml
 
   build-android:
-    runs-on: ubuntu-latest
-    env:
-      TURBO_CACHE_DIR: .turbo/android
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Cache turborepo for Android
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-turborepo-android-
-
-      - name: Check turborepo cache for Android
-        run: |
-          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:android').cache.status")
-
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
-          fi
-
-      - name: Install JDK
-        if: env.turbo_cache_hit != 1
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Finalize Android SDK
-        if: env.turbo_cache_hit != 1
-        run: |
-          /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
-
-      - name: Cache Gradle
-        if: env.turbo_cache_hit != 1
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('example/android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Build example for Android
-        run: |
-          yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
+    uses: ./.github/workflows/build_android.yml
 
   build-ios:
-    runs-on: macos-latest
-    env:
-      TURBO_CACHE_DIR: .turbo/ios
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "15.4"  
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Cache turborepo for iOS
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-turborepo-ios-
-
-      - name: Check turborepo cache for iOS
-        run: |
-          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
-
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
-          fi
-
-      - name: Cache cocoapods
-        if: env.turbo_cache_hit != 1
-        id: cocoapods-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/ios/Pods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cocoapods-
-
-      - name: Install cocoapods
-        if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'
-        run: |
-          yarn pod-install example/ios
-        env:
-          NO_FLIPPER: 1
-
-      - name: Build example for iOS
-        run: |
-          yarn turbo build:ios --cache-dir="{{ env.TURBO_CACHE_DIR }}"
+    uses: ./.github/workflows/build_ios.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Lint files
+        run: yarn lint
+
+      - name: Typecheck files
+        run: yarn typecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: unit-tests
+
+on: workflow_call
+
+jobs:
+  test:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup
+          uses: ./.github/actions/setup
+
+        - name: Run unit tests
+          run: yarn test --maxWorkers=2 --coverage


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows by modularizing the workflow definitions and reusing them across different jobs. The main changes include creating separate workflow files for building Android, iOS, and the library, as well as for linting and running tests. Additionally, the main CI workflow has been updated to reference these new modular workflows.

### Modularization of Workflows:

* Created a new workflow file for building Android applications (`.github/workflows/build-android.yml`).
* Created a new workflow file for building iOS applications (`.github/workflows/build-ios.yml`).
* Created a new workflow file for building the library (`.github/workflows/build-library.yml`).
* Created a new workflow file for linting files (`.github/workflows/lint.yml`).
* Created a new workflow file for running unit tests (`.github/workflows/tests.yml`).

### Updates to Main CI Workflow:

* Updated the main CI workflow (`.github/workflows/ci.yml`) to reference the new modular workflow files for linting, testing, building the library, and building Android and iOS applications.