### PR TITLE
fix: change text event name

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -36,16 +36,16 @@ jobs:
             echo "turbo_cache_hit=1" >> $GITHUB_ENV
           fi
 
-      # - name: Cache cocoapods
-      #   if: env.turbo_cache_hit != 1
-      #   id: cocoapods-cache
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: |
-      #       **/ios/Pods
-      #     key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cocoapods-
+      - name: Cache cocoapods
+        if: env.turbo_cache_hit != 1
+        id: cocoapods-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            **/ios/Pods
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
         if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -36,16 +36,16 @@ jobs:
             echo "turbo_cache_hit=1" >> $GITHUB_ENV
           fi
 
-      - name: Cache cocoapods
-        if: env.turbo_cache_hit != 1
-        id: cocoapods-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/ios/Pods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cocoapods-
+      # - name: Cache cocoapods
+      #   if: env.turbo_cache_hit != 1
+      #   id: cocoapods-cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: |
+      #       **/ios/Pods
+      #     key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
         if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'

--- a/android/src/main/java/com/maskedtextinput/managers/MaskedTextInputDecoratorViewManager.kt
+++ b/android/src/main/java/com/maskedtextinput/managers/MaskedTextInputDecoratorViewManager.kt
@@ -119,7 +119,7 @@ class MaskedTextInputDecoratorViewManager(
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     val export = super.getExportedCustomDirectEventTypeConstants() ?: newHashMap()
 
-    export[EventNames.CHANGE_TEXT_EVENT] = MapBuilder.of("registrationName", "onChangeText")
+    export[EventNames.CHANGE_TEXT_EVENT] = MapBuilder.of("registrationName", "onAdvancedMaskTextChange")
 
     return export
   }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -945,7 +945,7 @@ PODS:
   - React-Mapbuffer (0.73.10):
     - glog
     - React-debug
-  - react-native-advanced-input-mask (0.1.0):
+  - react-native-advanced-input-mask (1.0.0-beta.0):
     - ForkInputMask (~> 7.3.2)
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1355,7 +1355,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 71e5fb28b810fa199987e600ec8a6e17abee373e
   React-logger: 82babb1e3fad0e04750981f24e6c38f644a0bf7c
   React-Mapbuffer: 758750eb32350b01dd9c350010aecc46842047bd
-  react-native-advanced-input-mask: f2ab9a2e9a9bfe8b01489e353bd8bffa1217150c
+  react-native-advanced-input-mask: 6b83fdbaab6b94842242ae5740d2d6d4622d645d
   React-nativeconfig: a596be0c98c050b80bc7e262d46a53d4df4ff712
   React-NativeModulesApple: 4829cef81c8a322029300b6ff1c5f28768fca85b
   React-perflogger: 27b852c78b7be9e0b326e3102c6551529f371f95

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,8 +32,7 @@ export default function App() {
       <MaskedTextInput
         defaultValue=""
         style={styles.maskedTextInput}
-        onChangeText={onChangeText}
-        value={textState.formatted}
+        onAdvancedMaskTextChange={onChangeText}
         primaryMaskFormat="[00]-[00]-[00]"
         autocomplete={true}
         allowSuggestions={false}

--- a/ios/MaskedTextInput.swift
+++ b/ios/MaskedTextInput.swift
@@ -3,7 +3,7 @@ import Foundation
 import UIKit
 
 @objc protocol MaskedTextInputDecoratorViewDelegate {
-  func onChangeText(extracted: String, formatted: String)
+  func onAdvancedMaskTextChanged(extracted: String, formatted: String)
 }
 
 class MaskedTextInputDecoratorView: UIView {
@@ -12,8 +12,10 @@ class MaskedTextInputDecoratorView: UIView {
   var lastDispatchedEvent: [String: String] = [:]
 
   @objc weak var delegate: MaskedTextInputDecoratorViewDelegate?
+    
+  @objc var onAdvancedMaskTextChange: RCTBubblingEventBlock?;
 
-  @objc var onChangeTextCallback: (_ extracted: String, _ formatted: String) -> Void {
+  @objc var onAdvancedMaskTextChangedCallback: (_ extracted: String, _ formatted: String) -> Void {
     { [weak self] extracted, formatted in
       guard let self = self else { return }
 
@@ -26,8 +28,8 @@ class MaskedTextInputDecoratorView: UIView {
         return
       }
       lastDispatchedEvent = eventData
-      if self.onChangeText != nil {
-        self.onChangeText!(eventData)
+      if self.onAdvancedMaskTextChange != nil {
+        self.onAdvancedMaskTextChange!(eventData)
       }
     }
   }
@@ -169,7 +171,7 @@ class MaskedTextInputDecoratorView: UIView {
         affineFormats: affinityFormat,
         affinityCalculationStrategy: AffinityCalculationStrategy.forNumber(number: affinityCalculationStrategy), customNotations: (customNotations as? [[String: Any]])?.map { $0.toNotation() } ?? [],
         onMaskedTextChangedCallback: { input, value, _, _ in
-          self.onChangeTextCallback(value, input.allText)
+          self.onAdvancedMaskTextChangedCallback(value, input.allText)
         },
         allowSuggestions: allowSuggestions
       )

--- a/ios/MaskedTextInput.swift
+++ b/ios/MaskedTextInput.swift
@@ -12,8 +12,8 @@ class MaskedTextInputDecoratorView: UIView {
   var lastDispatchedEvent: [String: String] = [:]
 
   @objc weak var delegate: MaskedTextInputDecoratorViewDelegate?
-    
-  @objc var onAdvancedMaskTextChange: RCTBubblingEventBlock?;
+
+  @objc var onAdvancedMaskTextChange: RCTBubblingEventBlock?
 
   @objc var onAdvancedMaskTextChangedCallback: (_ extracted: String, _ formatted: String) -> Void {
     { [weak self] extracted, formatted in

--- a/ios/MaskedTextInputManager.mm
+++ b/ios/MaskedTextInputManager.mm
@@ -13,5 +13,5 @@
   RCT_EXPORT_VIEW_PROPERTY(defaultValue, NSString)
   RCT_EXPORT_VIEW_PROPERTY(value, NSString)
 
-  RCT_EXPORT_VIEW_PROPERTY(onChangeText, RCTBubblingEventBlock);
+  RCT_EXPORT_VIEW_PROPERTY(onAdvancedMaskTextChange, RCTBubblingEventBlock);
 @end

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef, memo, useCallback } from 'react';
 import MaskedTextInputDecoratorView from './MaskedTextInputNative';
 import type { MaskedTextInputDecoratorViewNativeProps } from './types';
 
-type MaskedTextInputProps = Omit<TextInputProps, 'onChangeText'> &
+type MaskedTextInputProps = TextInputProps &
   MaskedTextInputDecoratorViewNativeProps;
 
 const styles = StyleSheet.create({
@@ -35,17 +35,17 @@ const MaskedTextInput = memo<MaskedTextInputProps>(
         primaryMaskFormat,
         autoCapitalize = 'words',
         value,
-        onChangeText,
+        onAdvancedMaskTextChange,
         ...rest
       },
       ref
     ) => {
       const IS_FABRIC = 'nativeFabricUIManager' in global;
 
-      const onChangeTextCallback = useCallback(
+      const onAdvancedMaskTextChangeCallback = useCallback(
         ({ nativeEvent: { extracted, formatted } }) =>
-          onChangeText(extracted, formatted),
-        [onChangeText]
+          onAdvancedMaskTextChange(extracted, formatted),
+        [onAdvancedMaskTextChange]
       );
 
       return (
@@ -62,7 +62,7 @@ const MaskedTextInput = memo<MaskedTextInputProps>(
             customTransformation={customTransformation}
             defaultValue={defaultValue}
             isRTL={isRTL}
-            onChangeText={onChangeTextCallback}
+            onAdvancedMaskTextChange={onAdvancedMaskTextChangeCallback}
             primaryMaskFormat={primaryMaskFormat}
             style={IS_FABRIC ? styles.farAway : styles.displayNone}
             value={value}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,10 @@ export type Notation = {
 export type MaskedTextInputDecoratorViewNativeProps = ViewProps & {
   primaryMaskFormat: string;
   customNotations?: Notation[];
-  onChangeText: (extractedValue: string, formattedValue: string) => void;
+  onAdvancedMaskTextChange: (
+    extractedValue: string,
+    formattedValue: string
+  ) => void;
   affinityFormat?: string[];
   autocomplete?: boolean;
   autoSkip?: boolean;


### PR DESCRIPTION
These changes are addressed by changing the event name to onAdvancedMaskTextChange because of conflicts with the onChangeText event name from the react-native core.



