### PR TITLE
fix: align methods with react-native-text-input-mask

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,7 +20,7 @@ export default function App() {
     formatted: '',
   });
 
-  const onChangeText = React.useCallback((extracted, formatted) => {
+  const onChangeText = React.useCallback((formatted, extracted) => {
     console.log('extracted:', extracted, 'formatted:', formatted);
     setTextState({ extracted, formatted });
   }, []);
@@ -39,7 +39,7 @@ export default function App() {
         style={styles.maskedTextInput}
         onAdvancedMaskTextChange={onChangeText}
         onTailPlaceholderChange={console.log}
-        primaryMaskFormat="[00]-[$$]-[00]"
+        mask="[00]-[$$]-[00]"
         autocomplete={false}
         allowSuggestions={true}
         autocompleteOnFocus={false}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -37,7 +37,7 @@ export default function App() {
         defaultValue=""
         value={textState.formatted}
         style={styles.maskedTextInput}
-        onAdvancedMaskTextChange={onChangeText}
+        onChangeText={onChangeText}
         onTailPlaceholderChange={console.log}
         mask="[00]-[$$]-[00]"
         autocomplete={false}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ const MaskedTextInput = memo<MaskedTextInputProps>(
         customTransformation,
         defaultValue,
         isRTL,
-        primaryMaskFormat,
+        mask,
         autoCapitalize = 'words',
         value,
         onAdvancedMaskTextChange,
@@ -45,7 +45,7 @@ const MaskedTextInput = memo<MaskedTextInputProps>(
 
       const onAdvancedMaskTextChangeCallback = useCallback(
         ({ nativeEvent: { extracted, formatted, tailPlaceholder } }) => {
-          onAdvancedMaskTextChange?.(extracted, formatted);
+          onAdvancedMaskTextChange?.(formatted, extracted);
           onTailPlaceholderChange?.(tailPlaceholder);
         },
         [onAdvancedMaskTextChange, onTailPlaceholderChange]
@@ -66,7 +66,7 @@ const MaskedTextInput = memo<MaskedTextInputProps>(
             defaultValue={defaultValue}
             isRTL={isRTL}
             onAdvancedMaskTextChange={onAdvancedMaskTextChangeCallback}
-            primaryMaskFormat={primaryMaskFormat}
+            primaryMaskFormat={mask}
             style={IS_FABRIC ? styles.farAway : styles.displayNone}
             value={value}
           />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef, memo, useCallback } from 'react';
 import MaskedTextInputDecoratorView from './MaskedTextInputNative';
 import type { MaskedTextInputDecoratorViewNativeProps } from './types';
 
-type MaskedTextInputProps = TextInputProps &
+type MaskedTextInputProps = Omit<TextInputProps, 'onChangeText'> &
   MaskedTextInputDecoratorViewNativeProps;
 
 const styles = StyleSheet.create({
@@ -35,7 +35,7 @@ const MaskedTextInput = memo<MaskedTextInputProps>(
         mask,
         autoCapitalize = 'words',
         value,
-        onAdvancedMaskTextChange,
+        onChangeText,
         onTailPlaceholderChange,
         ...rest
       },
@@ -45,10 +45,10 @@ const MaskedTextInput = memo<MaskedTextInputProps>(
 
       const onAdvancedMaskTextChangeCallback = useCallback(
         ({ nativeEvent: { extracted, formatted, tailPlaceholder } }) => {
-          onAdvancedMaskTextChange?.(formatted, extracted);
+          onChangeText?.(formatted, extracted);
           onTailPlaceholderChange?.(tailPlaceholder);
         },
-        [onAdvancedMaskTextChange, onTailPlaceholderChange]
+        [onChangeText, onTailPlaceholderChange]
       );
 
       return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,11 +17,11 @@ export type Notation = {
 };
 
 export type MaskedTextInputDecoratorViewNativeProps = ViewProps & {
-  primaryMaskFormat: string;
+  mask: string;
   customNotations?: Notation[];
   onAdvancedMaskTextChange?: (
-    extractedValue: string,
-    formattedValue: string
+    formattedValue: string,
+    extractedValue: string
   ) => void;
   onTailPlaceholderChange?: (tailPlaceholder: string) => void;
   affinityFormat?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,10 +19,7 @@ export type Notation = {
 export type MaskedTextInputDecoratorViewNativeProps = ViewProps & {
   mask: string;
   customNotations?: Notation[];
-  onAdvancedMaskTextChange?: (
-    formattedValue: string,
-    extractedValue: string
-  ) => void;
+  onChangeText?: (formattedValue: string, extractedValue: string) => void;
   onTailPlaceholderChange?: (tailPlaceholder: string) => void;
   affinityFormat?: string[];
   autocomplete?: boolean;


### PR DESCRIPTION
## 📜 Description
Aligned methods with react-native-text-input-mask to make it easier to migrate projects from react-native-text-input-mask to this library

### JS

- primaryMaskFormat to mask
- onAdvancedMaskTextChange -> onChangeText

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested on iOS and Android

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->


https://github.com/user-attachments/assets/4eb36442-60ea-4abf-87e6-d27d39de890d



## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed