### PR TITLE
fix: focus/blur events don't work on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1243,7 +1243,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-advanced-input-mask (1.0.1):
+  - react-native-advanced-input-mask (1.1.0):
     - DoubleConversion
     - ForkInputMask (~> 7.3.2)
     - glog
@@ -1776,7 +1776,7 @@ SPEC CHECKSUMS:
   React-logger: 97c9dafae1f1a638001a9d1d0e93d431f2f9cb7b
   React-Mapbuffer: 3146a13424f9fec2ea1f1462d49d566e4d69b732
   React-microtasksnativemodule: 02d218c79c72d373a92a8552183f4ead0d1c6e05
-  react-native-advanced-input-mask: f7903f66ce9d97d70be9fa56be4f92313a2f9d67
+  react-native-advanced-input-mask: c0546f080108cec5988b565405b4513155ae087d
   React-nativeconfig: 93fe8c85a8c40820c57814e30f3e44b94c995a7b
   React-NativeModulesApple: b3e076fd0d7b73417fe1e8c8b26e3c57ae9b74aa
   React-perflogger: 1c55bcd3c392137cbaf0d21d8bb87ce9a0cebb15

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,10 +20,19 @@ export default function App() {
     formatted: '',
   });
 
+  const [focused, setFocused] = React.useState(false);
+
   const onChangeText = React.useCallback((formatted, extracted) => {
     console.log('extracted:', extracted, 'formatted:', formatted);
     setTextState({ extracted, formatted });
   }, []);
+
+  const onFocus = React.useCallback((e) => {
+    console.log(e.nativeEvent);
+    setFocused(true);
+  }, []);
+
+  const onBlur = React.useCallback(() => setFocused(false), []);
 
   const clearText = React.useCallback(() => {
     setTextState({ extracted: '', formatted: '' });
@@ -33,9 +42,12 @@ export default function App() {
     <View style={styles.container}>
       <Text>extracted value {textState.extracted}</Text>
       <Text>formatted value {textState.formatted}</Text>
+      <Text>focused {focused ? 'Yes' : 'No'}</Text>
       <MaskedTextInput
         defaultValue=""
         value={textState.formatted}
+        onFocus={onFocus}
+        onBlur={onBlur}
         style={styles.maskedTextInput}
         onChangeText={onChangeText}
         onTailPlaceholderChange={console.log}

--- a/ios/AdvancedInputMaskDelegateWrapper.swift
+++ b/ios/AdvancedInputMaskDelegateWrapper.swift
@@ -1,0 +1,40 @@
+//
+//  AdvancedInputMaskDelegateWrapper.swift
+//  react-native-advanced-input-mask
+//
+//  Created by Ivan Ignathuk on 01/11/2024.
+//
+
+import ForkInputMask
+import Foundation
+import UIKit
+
+class AdvancedInputMaskDelegateWrapper: NSObject, UITextFieldDelegate {
+  weak var textFieldDelegate: UITextFieldDelegate?
+
+  init(textFieldDelegate: UITextFieldDelegate?) {
+    self.textFieldDelegate = textFieldDelegate
+    super.init()
+  }
+
+  func textFieldDidEndEditing(_ textField: UITextField, reason _: UITextField.DidEndEditingReason) {
+    // since reason method doesn't exist in RN delegate, but we need this event to properly blur the input
+    textFieldDelegate?.textFieldDidEndEditing?(textField)
+  }
+
+  // MARK: call forwarding
+
+  override func responds(to aSelector: Selector!) -> Bool {
+    if super.responds(to: aSelector) {
+      return true
+    }
+    return textFieldDelegate?.responds(to: aSelector) ?? false
+  }
+
+  override func forwardingTarget(for aSelector: Selector!) -> Any? {
+    if textFieldDelegate?.responds(to: aSelector) ?? false {
+      return textFieldDelegate
+    }
+    return super.forwardingTarget(for: aSelector)
+  }
+}

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -20,6 +20,8 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   @objc weak var delegate: AdvancedTextInputMaskDecoratorViewDelegate?
 
+  @objc var textFieldDelegate: UITextFieldDelegate?
+
   @objc var onAdvancedMaskTextChange: RCTDirectEventBlock?
 
   @objc var onAdvancedMaskTextChangedCallback: (
@@ -217,9 +219,13 @@ class AdvancedTextInputMaskDecoratorView: UIView {
       },
       allowSuggestions: allowSuggestions
     )
-    let currentFieldDelegate = textView.delegate
-    maskInputListener?.textFieldDelegate = currentFieldDelegate
+
+    textFieldDelegate = AdvancedInputMaskDelegateWrapper(textFieldDelegate: textView.delegate)
+    maskInputListener?.textFieldDelegate = textFieldDelegate
     textView.delegate = maskInputListener
+
     updateTextWithoutNotification(text: defaultValue as String)
   }
 }
+
+class RCTMaskedTextFieldDelegateAdapter: RCTBackedTextViewDelegateAdapter {}

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -217,6 +217,8 @@ class AdvancedTextInputMaskDecoratorView: UIView {
       },
       allowSuggestions: allowSuggestions
     )
+    let currentFieldDelegate = textView.delegate
+    maskInputListener?.textFieldDelegate = currentFieldDelegate
     textView.delegate = maskInputListener
     updateTextWithoutNotification(text: defaultValue as String)
   }


### PR DESCRIPTION
## 📜 Description
Fixed focus/blur events are not firing on iOS. The problem was related to delegates logic, so, before setting the new delegate we needed to put the previous text field delegate to mask the input listener

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

onBlur/onFocus must work

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

**Before**

https://github.com/user-attachments/assets/702c3f86-4bf5-4aa0-a38e-3794111bdc96

**After**

https://github.com/user-attachments/assets/40a33e66-83bc-4568-af39-0694648d8a75




## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed