### PR TITLE
fix: android build error

### DIFF
--- a/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
+++ b/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
@@ -5,7 +5,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.SimpleViewManager
 
-abstract class AdvancedTextInputMaskDecoratorViewManagerSpec<T : View?> : SimpleViewManager<T>() {
+abstract class AdvancedTextInputMaskDecoratorViewManagerSpec<T : View> : SimpleViewManager<T>() {
   abstract fun setPrimaryMaskFormat(
     view: T,
     mask: String?,


### PR DESCRIPTION
## 📜 Description

With the newest `react-native` version 0.76.5 there is a build error when using `react-native-advanced-input-mask`:
```
> Task :react-native-advanced-input-mask:compileDebugKotlin FAILED
e: file:///Users/mlazari/Desktop/Repos/myapp/node_modules/react-native-advanced-input-mask/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt:8:93 Type argument is not within its bounds: should be subtype of 'View'
```

This is likely related to the rewriting of SimpleViewManager from Java to Kotlin in react-native 0.75.0: https://github.com/facebook/react-native/pull/43834/files#diff-23f2d98154bf6cbb23d2c455abe1e70d91962ed0a0460f2cce90adc28b9ddd18R20

## 💡 Motivation and Context

This change fixes an Android build error (`Type argument is not within its bounds: should be subtype of 'View'`) that happens with latest react-native version 0.76.5 and probably all react-native versions starting with 0.75.0 too.

## 📢 Changelog

### Android

- fix `Type argument is not within its bounds: should be subtype of 'View'` build error

## 🤔 How Has This Been Tested?

 - Create a new expo app with `npx create-expo-app@latest MyApp`
 - Install react-native-advanced-input-mask 1.1.2
 - Run `npx expo prebuild`
 - Run `npx expo run:android` and see the build error
 - Make the change in this PR (`View?` -> `View`) in `node_modules/react-native-advanced-input-mask/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt` and re-run `npx expo run:android`, see it builds without errors.
