### PR TITLE
fix: default value was not displayed on android on initial mount

### DIFF
--- a/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -75,11 +75,11 @@ class AdvancedTextInputMaskDecoratorView(
             affinityCalculationStrategy = affinityCalculationStrategy,
             allowedKeys = allowedKeys,
           )
-        
+
         val defaultValue = this.defaultValue
 
-        if(!defaultValue.isNullOrEmpty()) {
-           maskedTextChangeListener?.setText(defaultValue, true)
+        if (!defaultValue.isNullOrEmpty()) {
+          maskedTextChangeListener?.setText(defaultValue, true)
         }
       }
     }

--- a/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -28,6 +28,7 @@ class AdvancedTextInputMaskDecoratorView(
   private var customTransformationMethod: CustomTransformationMethod? = null
   private var maskedTextChangeListener: ReactMaskedTextChangeListener? = null
   private var allowedKeys: String? = null
+  private var defaultValue: String? = null
 
   private val valueListener =
     MaskedTextValueListener { _, extracted, formatted, tailPlaceholder ->
@@ -74,6 +75,12 @@ class AdvancedTextInputMaskDecoratorView(
             affinityCalculationStrategy = affinityCalculationStrategy,
             allowedKeys = allowedKeys,
           )
+        
+        val defaultValue = this.defaultValue
+
+        if(!defaultValue.isNullOrEmpty()) {
+           maskedTextChangeListener?.setText(defaultValue, true)
+        }
       }
     }
   }
@@ -115,6 +122,7 @@ class AdvancedTextInputMaskDecoratorView(
   }
 
   fun setDefaultValue(defaultValue: String?) {
+    this.defaultValue = defaultValue
     defaultValue?.let { maskedTextChangeListener?.setText(it, true) }
   }
 

--- a/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -42,6 +42,10 @@ class AdvancedTextInputMaskDecoratorView(
     maskedTextChangeListener?.setText(textField?.text.toString())
   }
 
+  private fun applyDefaultValue() {
+    defaultValue?.let { maskedTextChangeListener?.setText(it, false) }
+  }
+
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
@@ -76,11 +80,7 @@ class AdvancedTextInputMaskDecoratorView(
             allowedKeys = allowedKeys,
           )
 
-        val defaultValue = this.defaultValue
-
-        if (!defaultValue.isNullOrEmpty()) {
-          maskedTextChangeListener?.setText(defaultValue, true)
-        }
+        applyDefaultValue()
       }
     }
   }
@@ -123,7 +123,7 @@ class AdvancedTextInputMaskDecoratorView(
 
   fun setDefaultValue(defaultValue: String?) {
     this.defaultValue = defaultValue
-    defaultValue?.let { maskedTextChangeListener?.setText(it, true) }
+    applyDefaultValue()
   }
 
   fun setValue(value: String?) {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -54,7 +54,7 @@ export default function App() {
       <Text>focused {focused ? 'Yes' : 'No'}</Text>
       <MaskedTextInput
         ref={inputRef}
-        defaultValue=""
+        defaultValue="0000"
         value={textState.formatted}
         onFocus={onFocus}
         onBlur={onBlur}
@@ -94,6 +94,7 @@ const styles = StyleSheet.create({
   maskedTextInput: {
     width: '100%',
     height: 50,
+    color: 'red',
     backgroundColor: 'orange',
   },
 });


### PR DESCRIPTION
## 📜 Description

If we want to set default value for initial mount it should be done in onAttachedToWindow method. So, I added this and it fixed this problem.

### Android

- add set default value call in onAttachedToWindow

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Android emulator

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->

https://github.com/user-attachments/assets/b26ea676-8c01-466c-b1c4-5f0829a2ed55




## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed