### PR TITLE
fix: apply color for default value on iOS

### DIFF
--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -21,7 +21,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   // MARK: - Private Properties
 
-  private weak var textField: UITextField?
+  private weak var textField: RCTUITextField?
   private var maskInputListener: NotifyingAdvancedTexInputMaskListener?
   private var lastDispatchedEvent: [String: String] = [:]
   private var textFieldDelegate: UITextFieldDelegate?
@@ -94,7 +94,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   @objc private var defaultValue: NSString = "" {
     didSet {
-      updateTextWithoutNotification(text: defaultValue as String)
+     updateTextWithoutNotification(text: defaultValue as String)
     }
   }
 
@@ -213,6 +213,9 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
     configureTextField()
     configureMaskInputListener()
+
+    // reset the initial text before setting the default value
+    textField?.allText = ""
     updateTextWithoutNotification(text: defaultValue as String)
   }
 }
@@ -234,7 +237,7 @@ extension AdvancedTextInputMaskDecoratorView {
     #if ADVANCE_INPUT_MASK_NEW_ARCH_ENABLED
       if let parent = superview?.superview {
         for elementIndex in 1 ..< parent.subviews.count where parent.subviews[elementIndex] == superview {
-          textField = findFirstTextField(in: parent.subviews[elementIndex - 1])
+          textField = findFirstTextField(in: parent.subviews[elementIndex - 1]) as? RCTUITextField
           break
         }
       }


### PR DESCRIPTION
## 📜 Description

For sure I didn't do a deep investigation on "Why does it work like that???" but what I found: react-native initially sets attributed text as a text in RCTUITextField, so we need to reset it first and then apply default value

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- reset UITextField text on initial mount
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro simulator

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

https://github.com/user-attachments/assets/25bc6dfd-f028-4eac-b8d0-4a95617c0638



## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed