### PR TITLE
fix: advanced text input view is not cleaned up during recycling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ project.xcworkspace
 .idea
 .project
 .settings
+.kotlin
 local.properties
 android.iml
 

--- a/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -29,6 +29,7 @@ class AdvancedTextInputMaskDecoratorView(
   private var maskedTextChangeListener: ReactMaskedTextChangeListener? = null
   private var allowedKeys: String? = null
   private var defaultValue: String? = null
+  private var isInitialMount = true
 
   private val valueListener =
     MaskedTextValueListener { _, extracted, formatted, tailPlaceholder ->
@@ -80,9 +81,19 @@ class AdvancedTextInputMaskDecoratorView(
             allowedKeys = allowedKeys,
           )
 
-        applyDefaultValue()
+        if (isInitialMount) {
+          applyDefaultValue()
+          isInitialMount = false
+        }
       }
     }
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+    textField?.removeTextChangedListener(maskedTextChangeListener)
+    textField = null
+    maskedTextChangeListener = null
   }
 
   fun setMask(format: String) {

--- a/example/android/app/src/main/java/com/maskedtextinputexample/MainActivity.kt
+++ b/example/android/app/src/main/java/com/maskedtextinputexample/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.maskedtextinputexample
 
+import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -17,4 +18,8 @@ class MainActivity : ReactActivity() {
    * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate = DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+  }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1233,6 +1233,72 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-safe-area-context (5.1.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common (= 5.1.0)
+    - react-native-safe-area-context/fabric (= 5.1.0)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/common (5.1.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - react-native-safe-area-context/fabric (5.1.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - react-native-safe-area-context/common
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-nativeconfig (0.77.0)
   - React-NativeModulesApple (0.77.0):
     - glog
@@ -1522,6 +1588,51 @@ PODS:
     - React-logger (= 0.77.0)
     - React-perflogger (= 0.77.0)
     - React-utils (= 0.77.0)
+  - RNScreens (4.5.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNScreens/common (= 4.5.0)
+    - Yoga
+  - RNScreens/common (4.5.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -1565,6 +1676,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-advanced-input-mask (from `../..`)
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -1594,6 +1706,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1677,6 +1790,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   react-native-advanced-input-mask:
     :path: "../.."
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
   React-nativeconfig:
     :path: "../node_modules/react-native/ReactCommon"
   React-NativeModulesApple:
@@ -1735,6 +1850,8 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNScreens:
+    :path: "../node_modules/react-native-screens"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -1777,6 +1894,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 99bd566147aaa78e872568be53ebca8a4449ddae
   React-microtasksnativemodule: 51e7813abf875408a0f367e473a65bbab6aa8481
   react-native-advanced-input-mask: cc5972e991517c49dd4a6867a5c10df7b639d77c
+  react-native-safe-area-context: efd435f89b73d91f37438e5ac2d725f0e7adff95
   React-nativeconfig: cd0fbb40987a9658c24dab5812c14e5522a64929
   React-NativeModulesApple: 4a9c304aa4fb086af32e8758ba892386d895b4d3
   React-perflogger: 721172bda31a65ce7b7a0c3bf3de96f12ef6f45d
@@ -1806,6 +1924,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6e8d68583f39dc31ee65235110287277eb8556ef
   ReactCodegen: c08a5113d9c9c895fe10f3c296f74c6b705a60a9
   ReactCommon: 1bd2dc684d7992acbf0dfee887b89a57a1ead86d
+  RNScreens: 5d61e452b51e7c23b3fcb9f16c4967d683a60a9d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c0d8564af14a858f962607cd7306539cb2ace926
 

--- a/example/package.json
+++ b/example/package.json
@@ -10,8 +10,12 @@
     "build:ios": "cd ios && xcodebuild -workspace MaskedTextInputExample.xcworkspace -scheme MaskedTextInputExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO | xcpretty"
   },
   "dependencies": {
+    "@react-navigation/native": "^7.0.14",
+    "@react-navigation/native-stack": "^7.2.0",
     "react": "18.3.1",
-    "react-native": "0.77.0"
+    "react-native": "0.77.0",
+    "react-native-safe-area-context": "^5.1.0",
+    "react-native-screens": "^4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,100 +1,14 @@
 import * as React from 'react';
-
-import { Button, StyleSheet, Text, TextInput, View } from 'react-native';
-import { MaskedTextInput } from 'react-native-advanced-input-mask';
-
-const alphaNumericChars =
-  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
-const charAlphaNumerics = [
-  {
-    character: '$',
-    characterSet: alphaNumericChars,
-    isOptional: false,
-  },
-];
+import Navigation from './navigation';
+import {
+  initialWindowMetrics,
+  SafeAreaProvider,
+} from 'react-native-safe-area-context';
 
 export default function App() {
-  const inputRef = React.useRef<TextInput>(null);
-
-  const [textState, setTextState] = React.useState({
-    extracted: '',
-    formatted: '',
-  });
-
-  const [focused, setFocused] = React.useState(false);
-
-  const onChangeText = React.useCallback(
-    (formatted: string, extracted: string) => {
-      console.log('extracted:', extracted, 'formatted:', formatted);
-      setTextState({ extracted, formatted });
-    },
-    []
-  );
-
-  const onFocus = React.useCallback((e) => {
-    console.log(e.nativeEvent);
-    setFocused(true);
-  }, []);
-
-  const onBlur = React.useCallback(() => setFocused(false), []);
-
-  const clearText = React.useCallback(() => {
-    setTextState({ extracted: '', formatted: '' });
-  }, []);
-
-  const onFocusButtonPress = React.useCallback(() => {
-    inputRef.current?.focus();
-  }, []);
-
   return (
-    <View style={styles.container}>
-      <Text>extracted value {textState.extracted}</Text>
-      <Text>formatted value {textState.formatted}</Text>
-      <Text>focused {focused ? 'Yes' : 'No'}</Text>
-      <MaskedTextInput
-        ref={inputRef}
-        defaultValue="0000"
-        value={textState.formatted}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        style={styles.maskedTextInput}
-        onChangeText={onChangeText}
-        onTailPlaceholderChange={console.log}
-        mask="[00]-[$$]-[00]"
-        autocomplete={false}
-        allowSuggestions={true}
-        autocompleteOnFocus={false}
-        autoSkip={false}
-        customNotations={charAlphaNumerics}
-      />
-      <Button title="Clear text" onPress={clearText} />
-      <Button title="Focus text input" onPress={onFocusButtonPress} />
-    </View>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <Navigation />
+    </SafeAreaProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  box: {
-    width: 60,
-    height: 60,
-    marginVertical: 20,
-  },
-  textInputMaskInput: {
-    width: '100%',
-    height: 50,
-    backgroundColor: 'lightblue',
-  },
-  maskedTextInput: {
-    width: '100%',
-    height: 50,
-    color: 'red',
-    backgroundColor: 'orange',
-  },
-});

--- a/example/src/navigation/Root/index.tsx
+++ b/example/src/navigation/Root/index.tsx
@@ -1,0 +1,18 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ScreenNames from '../screenNames';
+import Main from '../../screens/Main';
+import RNTextInput from '../../screens/RNTextInput';
+
+const RootStack = createNativeStackNavigator({
+  initialRouteName: ScreenNames.Main,
+  screens: {
+    [ScreenNames.Main]: {
+      screen: Main,
+    },
+    [ScreenNames.RNTextInput]: {
+      screen: RNTextInput,
+    },
+  },
+});
+
+export default RootStack;

--- a/example/src/navigation/Root/types.ts
+++ b/example/src/navigation/Root/types.ts
@@ -1,0 +1,10 @@
+import type { StaticParamList } from '@react-navigation/native';
+import RootStack from './index';
+
+export type RootStackParamList = StaticParamList<typeof RootStack>;
+
+declare global {
+  namespace ReactNavigation {
+    interface RootParamList extends RootStackParamList {}
+  }
+}

--- a/example/src/navigation/index.tsx
+++ b/example/src/navigation/index.tsx
@@ -1,0 +1,9 @@
+import { createStaticNavigation } from '@react-navigation/native';
+import RootStack from './Root';
+import ScreenNames from './screenNames';
+
+const Navigation = createStaticNavigation(RootStack);
+
+export { ScreenNames };
+
+export default Navigation;

--- a/example/src/navigation/screenNames.ts
+++ b/example/src/navigation/screenNames.ts
@@ -1,0 +1,6 @@
+const enum ScreenNames {
+  Main = 'Main',
+  RNTextInput = 'RNTextInput',
+}
+
+export default ScreenNames;

--- a/example/src/screens/Main/index.tsx
+++ b/example/src/screens/Main/index.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+
+import { Button, ScrollView, Text, TextInput } from 'react-native';
+import { MaskedTextInput } from 'react-native-advanced-input-mask';
+import styles from './styles';
+import { useNavigation } from '@react-navigation/native';
+import { ScreenNames } from '../../navigation';
+
+const alphaNumericChars =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+const charAlphaNumerics = [
+  {
+    character: '$',
+    characterSet: alphaNumericChars,
+    isOptional: false,
+  },
+];
+
+const Main = () => {
+  const { reset, navigate } = useNavigation();
+
+  const inputRef = React.useRef<TextInput>(null);
+
+  const [textState, setTextState] = React.useState({
+    extracted: '',
+    formatted: '',
+  });
+
+  const [focused, setFocused] = React.useState(false);
+
+  const onChangeText = React.useCallback(
+    (formatted: string, extracted: string) => {
+      console.log('extracted:', extracted, 'formatted:', formatted);
+      setTextState({ extracted, formatted });
+    },
+    []
+  );
+
+  const onFocus = React.useCallback((e) => {
+    console.log(e.nativeEvent);
+    setFocused(true);
+  }, []);
+
+  const onBlur = React.useCallback(() => setFocused(false), []);
+
+  const clearText = React.useCallback(() => {
+    setTextState({ extracted: '', formatted: '' });
+  }, []);
+
+  const onFocusButtonPress = React.useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleNavigateToRNTextInputButtonPress = React.useCallback(() => {
+    navigate(ScreenNames.RNTextInput);
+  }, [navigate]);
+
+  const navigateToRNTextInputWithReset = React.useCallback(() => {
+    reset({ index: 0, routes: [{ name: ScreenNames.RNTextInput }] });
+  }, [reset]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text>extracted value {textState.extracted}</Text>
+      <Text>formatted value {textState.formatted}</Text>
+      <Text>focused {focused ? 'Yes' : 'No'}</Text>
+      <MaskedTextInput
+        ref={inputRef}
+        defaultValue="0000"
+        value={textState.formatted}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        style={styles.maskedTextInput}
+        onChangeText={onChangeText}
+        onTailPlaceholderChange={console.log}
+        mask="[00]-[$$]-[00]"
+        autocomplete={false}
+        allowSuggestions={true}
+        autocompleteOnFocus={false}
+        autoSkip={false}
+        customNotations={charAlphaNumerics}
+      />
+      <Button title="Clear text" onPress={clearText} />
+      <Button title="Focus text input" onPress={onFocusButtonPress} />
+      <Button
+        title="Navigate to RN text input screen"
+        onPress={handleNavigateToRNTextInputButtonPress}
+      />
+      <Button
+        title="Navigate to RN text input screen with reset"
+        onPress={navigateToRNTextInputWithReset}
+      />
+    </ScrollView>
+  );
+};
+
+export default Main;

--- a/example/src/screens/Main/index.tsx
+++ b/example/src/screens/Main/index.tsx
@@ -31,7 +31,6 @@ const Main = () => {
 
   const onChangeText = React.useCallback(
     (formatted: string, extracted: string) => {
-      console.log('extracted:', extracted, 'formatted:', formatted);
       setTextState({ extracted, formatted });
     },
     []
@@ -73,6 +72,38 @@ const Main = () => {
         onBlur={onBlur}
         style={styles.maskedTextInput}
         onChangeText={onChangeText}
+        onTailPlaceholderChange={console.log}
+        mask="[00]-[$$]-[00]"
+        autocomplete={false}
+        allowSuggestions={true}
+        autocompleteOnFocus={false}
+        autoSkip={false}
+        customNotations={charAlphaNumerics}
+      />
+      <MaskedTextInput
+        ref={inputRef}
+        defaultValue="0000"
+        // value={textState.formatted}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        style={styles.maskedTextInput}
+        // onChangeText={onChangeText}
+        onTailPlaceholderChange={console.log}
+        mask="[00]-[$$]-[00]"
+        autocomplete={false}
+        allowSuggestions={true}
+        autocompleteOnFocus={false}
+        autoSkip={false}
+        customNotations={charAlphaNumerics}
+      />
+      <MaskedTextInput
+        ref={inputRef}
+        defaultValue="0000"
+        // value={textState.formatted}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        style={styles.maskedTextInput}
+        // onChangeText={onChangeText}
         onTailPlaceholderChange={console.log}
         mask="[00]-[$$]-[00]"
         autocomplete={false}

--- a/example/src/screens/Main/index.tsx
+++ b/example/src/screens/Main/index.tsx
@@ -80,38 +80,6 @@ const Main = () => {
         autoSkip={false}
         customNotations={charAlphaNumerics}
       />
-      <MaskedTextInput
-        ref={inputRef}
-        defaultValue="0000"
-        // value={textState.formatted}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        style={styles.maskedTextInput}
-        // onChangeText={onChangeText}
-        onTailPlaceholderChange={console.log}
-        mask="[00]-[$$]-[00]"
-        autocomplete={false}
-        allowSuggestions={true}
-        autocompleteOnFocus={false}
-        autoSkip={false}
-        customNotations={charAlphaNumerics}
-      />
-      <MaskedTextInput
-        ref={inputRef}
-        defaultValue="0000"
-        // value={textState.formatted}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        style={styles.maskedTextInput}
-        // onChangeText={onChangeText}
-        onTailPlaceholderChange={console.log}
-        mask="[00]-[$$]-[00]"
-        autocomplete={false}
-        allowSuggestions={true}
-        autocompleteOnFocus={false}
-        autoSkip={false}
-        customNotations={charAlphaNumerics}
-      />
       <Button title="Clear text" onPress={clearText} />
       <Button title="Focus text input" onPress={onFocusButtonPress} />
       <Button

--- a/example/src/screens/Main/styles.ts
+++ b/example/src/screens/Main/styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  maskedTextInput: {
+    width: '100%',
+    height: 50,
+    color: 'red',
+    backgroundColor: 'orange',
+  },
+});
+
+export default styles;

--- a/example/src/screens/RNTextInput/index.tsx
+++ b/example/src/screens/RNTextInput/index.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { TextInput, View } from 'react-native';
+import styles from './styles';
+
+const RNTextInput = () => {
+  return (
+    <View style={styles.container}>
+      <TextInput style={styles.textInput} />
+    </View>
+  );
+};
+
+export default RNTextInput;

--- a/example/src/screens/RNTextInput/styles.ts
+++ b/example/src/screens/RNTextInput/styles.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  textInput: {
+    width: '100%',
+    height: 50,
+    backgroundColor: 'lightblue',
+  },
+});
+
+export default styles;

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -201,32 +201,30 @@ class AdvancedTextInputMaskDecoratorView: UIView {
       },
       allowSuggestions: allowSuggestions
     )
-
     maskInputListener?.textFieldDelegate = textFieldDelegate
     maskInputListener?.allowedKeys = (allowedKeys ?? "") as String
     textField.delegate = maskInputListener
   }
 
   @objc func cleanup() {
-    textField?.delegate = nil
+    textField = nil
     maskInputListener?.textFieldDelegate = nil
     maskInputListener = nil
-    textFieldDelegate = nil
-    textField = nil
-    delegate = nil
   }
 
   // MARK: - View Lifecycle
 
   override func didMoveToWindow() {
-    configureTextField()
-    configureMaskInputListener()
+    if textField == nil {
+      configureTextField()
+      configureMaskInputListener()
 
-    if isInitialMount {
-      // reset the initial text before setting the default value
-      textField?.allText = ""
-      updateTextWithoutNotification(text: defaultValue as String)
-      isInitialMount = false
+      if isInitialMount {
+        // reset the initial text before setting the default value
+        textField?.allText = ""
+        updateTextWithoutNotification(text: defaultValue as String)
+        isInitialMount = false
+      }
     }
   }
 }

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -21,10 +21,11 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   // MARK: - Private Properties
 
-  private weak var textField: RCTUITextField?
+  private weak var textField: UITextField?
   private var maskInputListener: NotifyingAdvancedTexInputMaskListener?
   private var lastDispatchedEvent: [String: String] = [:]
   private var textFieldDelegate: UITextFieldDelegate?
+  private var isInitialMount = true
 
   @objc private var primaryMaskFormat: NSString = "" {
     didSet {
@@ -206,17 +207,27 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     textField.delegate = maskInputListener
   }
 
+  @objc func cleanup() {
+    textField?.delegate = nil
+    maskInputListener?.textFieldDelegate = nil
+    maskInputListener = nil
+    textFieldDelegate = nil
+    textField = nil
+    delegate = nil
+  }
+
   // MARK: - View Lifecycle
 
   override func didMoveToWindow() {
-    super.didMoveToWindow()
-
     configureTextField()
     configureMaskInputListener()
 
-    // reset the initial text before setting the default value
-    textField?.allText = ""
-    updateTextWithoutNotification(text: defaultValue as String)
+    if isInitialMount {
+      // reset the initial text before setting the default value
+      textField?.allText = ""
+      updateTextWithoutNotification(text: defaultValue as String)
+      isInitialMount = false
+    }
   }
 }
 
@@ -237,7 +248,7 @@ extension AdvancedTextInputMaskDecoratorView {
     #if ADVANCE_INPUT_MASK_NEW_ARCH_ENABLED
       if let parent = superview?.superview {
         for elementIndex in 1 ..< parent.subviews.count where parent.subviews[elementIndex] == superview {
-          textField = findFirstTextField(in: parent.subviews[elementIndex - 1]) as? RCTUITextField
+          textField = findFirstTextField(in: parent.subviews[elementIndex - 1])
           break
         }
       }

--- a/ios/AdvancedTextInputViewContainer.h
+++ b/ios/AdvancedTextInputViewContainer.h
@@ -30,4 +30,5 @@
 - (void)setValue:(NSString *)value;
 - (void)setAffinityFormat:(NSArray<NSString *> *)affinityFormat;
 - (void)setAffinityCalculationStrategy:(NSInteger)affinityCalculationStrategy;
+- (void)cleanup;
 @end

--- a/ios/AdvancedtextInputMaskDecoratorView.mm
+++ b/ios/AdvancedtextInputMaskDecoratorView.mm
@@ -55,10 +55,10 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle
 {
-    [super prepareForRecycle];
-    [_view cleanup];
-    _view.delegate = nil;
-    _view = nil;
+  [super prepareForRecycle];
+  [_view cleanup];
+  _view.delegate = nil;
+  _view = nil;
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/AdvancedtextInputMaskDecoratorView.mm
+++ b/ios/AdvancedtextInputMaskDecoratorView.mm
@@ -55,10 +55,10 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle
 {
-  [super prepareForRecycle];
-  [_view cleanup];
-  _view.delegate = nil;
-  _eventEmitter = nil;
+    [super prepareForRecycle];
+    [_view cleanup];
+    _view.delegate = nil;
+    _view = nil;
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/AdvancedtextInputMaskDecoratorView.mm
+++ b/ios/AdvancedtextInputMaskDecoratorView.mm
@@ -53,6 +53,14 @@ using namespace facebook::react;
   return self;
 }
 
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+  [_view cleanup];
+  _view.delegate = nil;
+  _eventEmitter = nil;
+}
+
 #pragma mark - RCTComponentViewProtocol
 
 + (ComponentDescriptorProvider)componentDescriptorProvider

--- a/yarn.lock
+++ b/yarn.lock
@@ -4058,6 +4058,82 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-navigation/core@npm:^7.3.1":
+  version: 7.3.1
+  resolution: "@react-navigation/core@npm:7.3.1"
+  dependencies:
+    "@react-navigation/routers": ^7.1.2
+    escape-string-regexp: ^4.0.0
+    nanoid: 3.3.8
+    query-string: ^7.1.3
+    react-is: ^18.2.0
+    use-latest-callback: ^0.2.1
+    use-sync-external-store: ^1.2.2
+  peerDependencies:
+    react: ">= 18.2.0"
+  checksum: 609482947cd32e878a0ed68da5d870cd4d40b64d123c55cb4b61e6fe7be43d66537416e0bf4a417d91a70a2eb428dfc5f59a76a11ded7e26454af2d872b80508
+  languageName: node
+  linkType: hard
+
+"@react-navigation/elements@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "@react-navigation/elements@npm:2.2.5"
+  dependencies:
+    color: ^4.2.3
+  peerDependencies:
+    "@react-native-masked-view/masked-view": ">= 0.2.0"
+    "@react-navigation/native": ^7.0.14
+    react: ">= 18.2.0"
+    react-native: "*"
+    react-native-safe-area-context: ">= 4.0.0"
+  peerDependenciesMeta:
+    "@react-native-masked-view/masked-view":
+      optional: true
+  checksum: 226dbf0350eb65a45cd488421a39338f321dfd44fc15ba8b37385799707446ae7563ab417ec00f6bed6caf25e5348fed7485c2ad26e48b160fa6216ef1bc5d2e
+  languageName: node
+  linkType: hard
+
+"@react-navigation/native-stack@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@react-navigation/native-stack@npm:7.2.0"
+  dependencies:
+    "@react-navigation/elements": ^2.2.5
+    warn-once: ^0.1.1
+  peerDependencies:
+    "@react-navigation/native": ^7.0.14
+    react: ">= 18.2.0"
+    react-native: "*"
+    react-native-safe-area-context: ">= 4.0.0"
+    react-native-screens: ">= 4.0.0"
+  checksum: c8202080416307cf7e2502e82e92f3dc09a17b96051f26d1e103fa222ff12729d1dd049c6f747e45cf03698ff019ab27d70f48e2e505606e4be5ade692e1b9a9
+  languageName: node
+  linkType: hard
+
+"@react-navigation/native@npm:^7.0.14":
+  version: 7.0.14
+  resolution: "@react-navigation/native@npm:7.0.14"
+  dependencies:
+    "@react-navigation/core": ^7.3.1
+    escape-string-regexp: ^4.0.0
+    fast-deep-equal: ^3.1.3
+    nanoid: 3.3.8
+    use-latest-callback: ^0.2.1
+  peerDependencies:
+    react: ">= 18.2.0"
+    react-native: "*"
+  checksum: 2bc64d232fa467ad08a02cd7e6120e970e7d2bef8614759acfe1f4fcb08f08b606e6f838fda6a4c392f5464bf21bbd7782c6d48b5e1d9f9f7762b11fbdd2ea8d
+  languageName: node
+  linkType: hard
+
+"@react-navigation/routers@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "@react-navigation/routers@npm:7.1.2"
+  dependencies:
+    nanoid: 3.3.8
+  checksum: 651170c4201963eb478b9439738173a1dd0a6500a3ad5cecd78c61846086de56f0b9cec1f21f902c3705da99844086186320dab7700cec25be84bc463cd90475
+  languageName: node
+  linkType: hard
+
 "@release-it/conventional-changelog@npm:^5.0.0":
   version: 5.1.1
   resolution: "@release-it/conventional-changelog@npm:5.1.1"
@@ -6045,10 +6121,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
+  languageName: node
+  linkType: hard
+
+"color@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "color@npm:4.2.3"
+  dependencies:
+    color-convert: ^2.0.1
+    color-string: ^1.9.0
+  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -6790,6 +6886,13 @@ __metadata:
   version: 5.0.1
   resolution: "decamelize@npm:5.0.1"
   checksum: 7c3b1ed4b3e60e7fbc00a35fb248298527c1cdfe603e41dfcf05e6c4a8cb9efbee60630deb677ed428908fb4e74e322966c687a094d1478ddc9c3a74e9dc7140
+  languageName: node
+  linkType: hard
+
+"decode-uri-component@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "decode-uri-component@npm:0.2.2"
+  checksum: 95476a7d28f267292ce745eac3524a9079058bbb35767b76e3ee87d42e34cd0275d2eb19d9d08c3e167f97556e8a2872747f5e65cbebcac8b0c98d83e285f139
   languageName: node
   linkType: hard
 
@@ -8185,6 +8288,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"filter-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "filter-obj@npm:1.1.0"
+  checksum: cf2104a7c45ff48e7f505b78a3991c8f7f30f28bd8106ef582721f321f1c6277f7751aacd5d83026cb079d9d5091082f588d14a72e7c5d720ece79118fa61e10
+  languageName: node
+  linkType: hard
+
 "finalhandler@npm:1.1.2":
   version: 1.1.2
   resolution: "finalhandler@npm:1.1.2"
@@ -9386,6 +9496,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: eef4417e3c10e60e2c810b6084942b3ead455af16c4509959a27e490e7aee87cfb3f38e01bbde92220b528a0ee1a18d52b787e1458ee86174d8c7f0e58cd488f
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
   languageName: node
   linkType: hard
 
@@ -12030,7 +12147,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.7":
+"nanoid@npm:3.3.8, nanoid@npm:^3.3.7":
   version: 3.3.8
   resolution: "nanoid@npm:3.3.8"
   bin:
@@ -13243,6 +13360,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"query-string@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "query-string@npm:7.1.3"
+  dependencies:
+    decode-uri-component: ^0.2.2
+    filter-obj: ^1.1.0
+    split-on-first: ^1.0.0
+    strict-uri-encode: ^2.0.0
+  checksum: 91af02dcd9cc9227a052841d5c2eecb80a0d6489d05625df506a097ef1c59037cfb5e907f39b84643cbfd535c955abec3e553d0130a7b510120c37d06e0f4346
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -13326,6 +13455,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-freeze@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "react-freeze@npm:1.0.4"
+  peerDependencies:
+    react: ">=17.0.0"
+  checksum: 6b4d93209dff04a1f25d9f8e0c56a9a8a80e7889e8e8267299f34449c7e41a9ab90cad24569d03dd7173b56b7496576dba68f71f1d4e5c8be72f0633023668bc
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -13340,7 +13478,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.0.0":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
@@ -13361,10 +13499,14 @@ __metadata:
     "@react-native/eslint-config": 0.77.0
     "@react-native/metro-config": 0.77.0
     "@react-native/typescript-config": 0.77.0
+    "@react-navigation/native": ^7.0.14
+    "@react-navigation/native-stack": ^7.2.0
     babel-plugin-module-resolver: ^5.0.0
     pod-install: ^0.1.0
     react: 18.3.1
     react-native: 0.77.0
+    react-native-safe-area-context: ^5.1.0
+    react-native-screens: ^4.5.0
   languageName: unknown
   linkType: soft
 
@@ -13433,6 +13575,29 @@ __metadata:
   bin:
     bob: bin/bob
   checksum: 258da6ecd03be52cc05a3e3a7c481890c7c0b7b62ae9f263c5f3d6fafeae95bd9445ad2f6c2513f7f4e4569eee935a18ae94c7491f58d6916af515c88de9e0a1
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "react-native-safe-area-context@npm:5.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: b03663c8567f24ff9e0fd96f0b06b8b4e3aebb77dd93995cc661996aa6e70f8e96588e78006696277b7c213b65ac9515604d57bd0321b96e42b0a055b3b49f7e
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "react-native-screens@npm:4.5.0"
+  dependencies:
+    react-freeze: ^1.0.0
+    warn-once: ^0.1.0
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 866dbc4803980ce589a212c1a8b15f8cdf428f39895b00edfcc9aaf5f658c8fce0ddf37e7f8d259e4f7385909485c0720209ca6fc5f8ebd8531a7b2ec07fc658
   languageName: node
   linkType: hard
 
@@ -14564,6 +14729,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: ^0.3.1
+  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -14706,6 +14880,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-on-first@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "split-on-first@npm:1.1.0"
+  checksum: 16ff85b54ddcf17f9147210a4022529b343edbcbea4ce977c8f30e38408b8d6e0f25f92cd35b86a524d4797f455e29ab89eb8db787f3c10708e0b47ebf528d30
+  languageName: node
+  linkType: hard
+
 "split2@npm:^3.0.0, split2@npm:^3.2.2":
   version: 3.2.2
   resolution: "split2@npm:3.2.2"
@@ -14808,6 +14989,13 @@ __metadata:
   version: 2.2.0
   resolution: "stream-buffers@npm:2.2.0"
   checksum: 4587d9e8f050d689fb38b4295e73408401b16de8edecc12026c6f4ae92956705ecfd995ae3845d7fa3ebf19502d5754df9143d91447fd881d86e518f43882c1c
+  languageName: node
+  linkType: hard
+
+"strict-uri-encode@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strict-uri-encode@npm:2.0.0"
+  checksum: eaac4cf978b6fbd480f1092cab8b233c9b949bcabfc9b598dd79a758f7243c28765ef7639c876fa72940dac687181b35486ea01ff7df3e65ce3848c64822c581
   languageName: node
   linkType: hard
 
@@ -15821,6 +16009,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-latest-callback@npm:^0.2.1":
+  version: 0.2.3
+  resolution: "use-latest-callback@npm:0.2.3"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 5db2dc0d414508c768ba4d1a337bd73dd0fb2a77eccc9dd7051517b28cd71c849c5e9230b5c97fc76a3811c1500f210cb4e4ebb95fe20347e5f910509a8e533c
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.2.2":
+  version: 1.4.0
+  resolution: "use-sync-external-store@npm:1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: dc3843a1b59ac8bd01417bd79498d4c688d5df8bf4801be50008ef4bfaacb349058c0b1605b5b43c828e0a2d62722d7e861573b3f31cea77a7f23e8b0fc2f7e3
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -15920,6 +16126,13 @@ __metadata:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
+  languageName: node
+  linkType: hard
+
+"warn-once@npm:^0.1.0, warn-once@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "warn-once@npm:0.1.1"
+  checksum: e6a5a1f5a8dba7744399743d3cfb571db4c3947897875d4962a7c5b1bf2195ab4518c838cb4cea652e71729f21bba2e98dc75686f5fccde0fabbd894e2ed0c0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📜 Description

The problem was in AdvancedTextInputMaskDecoratorView. When we navigated from one screen to another we applied a logic to find a new text input component and apply mask logic for it but it is wrong. I added prepareForRecycle method in objective-c method and added cleanup function to remove all strong references. 

I also added navigation to my codebase, so in the future this will help me split the codebase and cover it better with E2E tests.

fixes #44 

### JS

- navigation
-

### iOS

- prepareForRecycle method in AdvancedTextInputMaskDecoratorView(objective-c)
- cleanup method in AdvancedTextInputMaskDecoratorView(swift)
- added handling of initial mount

### Android

- added clean up for change text listeners
- added handling of initial mount

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro simulator

Pixel 6a API 35

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### Android 

#### new arch:

https://github.com/user-attachments/assets/61594511-a61b-45b2-9a02-b0e3a269c1f9

##### old arch:


https://github.com/user-attachments/assets/557de49a-7a7a-45d0-bdb1-81099a4044a7


### iOS

#### new arch:

https://github.com/user-attachments/assets/e17e1b35-af92-4d61-b580-19517e41c5bf

#### old arch:


https://github.com/user-attachments/assets/df57a4e7-73d6-4e93-ae30-0079a4eed3a0





## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed