### PR TITLE
fix: update text value when allowedKeys has been changed

### DIFF
--- a/WebExample/src/App.tsx
+++ b/WebExample/src/App.tsx
@@ -54,7 +54,6 @@ export default function App() {
       <Text>focused {focused ? 'Yes' : 'No'}</Text>
       <MaskedTextInput
         ref={inputRef}
-        defaultValue="0000"
         value={textState.formatted}
         onFocus={onFocus}
         onBlur={onBlur}

--- a/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -159,5 +159,6 @@ class AdvancedTextInputMaskDecoratorView(
   fun setAllowedKeys(allowedKeys: String?) {
     this.allowedKeys = allowedKeys
     maskedTextChangeListener?.allowedKeys = allowedKeys
+    maybeUpdateText()
   }
 }

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
   # trailing comma is forced by swiftformat
   - trailing_comma
+  - opening_brace
 
 line_length:
   warning: 120

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -93,7 +93,8 @@ class AdvancedTextInputMaskDecoratorView: UIView {
       maskInputListener?.allowedKeys = allowedKeys
       guard let textField = textField else { return }
       if !allowedKeys.isEmpty {
-        textField.allText = textField.allText.filter { allowedKeys.contains($0) }
+        let nextText = textField.allText.filter { allowedKeys.contains($0) }
+        updateTextWithoutNotification(text: nextText)
       }
     }
   }

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -89,7 +89,12 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   @objc private var allowedKeys: NSString? {
     didSet {
-      maskInputListener?.allowedKeys = (allowedKeys ?? "") as String
+      let allowedKeys = (allowedKeys ?? "") as String
+      maskInputListener?.allowedKeys = allowedKeys
+      guard let textField = textField else { return }
+      if !allowedKeys.isEmpty {
+        textField.allText = textField.allText.filter { allowedKeys.contains($0) }
+      }
     }
   }
 
@@ -199,10 +204,10 @@ class AdvancedTextInputMaskDecoratorView: UIView {
           tailPlaceholder: tailPlaceholder
         )
       },
-      allowSuggestions: allowSuggestions
+      allowSuggestions: allowSuggestions,
+      allowedKeys: (allowedKeys ?? "") as String
     )
     maskInputListener?.textFieldDelegate = textFieldDelegate
-    maskInputListener?.allowedKeys = (allowedKeys ?? "") as String
     textField.delegate = maskInputListener
   }
 

--- a/ios/NotifyingAdvancedTexInputMaskListener.swift
+++ b/ios/NotifyingAdvancedTexInputMaskListener.swift
@@ -20,11 +20,26 @@ class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
               affineFormats: [String] = [],
               affinityCalculationStrategy: AffinityCalculationStrategy = .wholeString,
               customNotations: [Notation] = [],
-              onMaskedTextChangedCallback: ((_ textInput: UITextInput, _ value: String, _ complete: Bool, _ tailPlaceholder: String) -> Void)? = nil,
+              onMaskedTextChangedCallback: (
+                (_ textInput: UITextInput,
+                 _ value: String,
+                 _ complete: Bool,
+                 _ tailPlaceholder: String) -> Void)? = nil,
               allowSuggestions: Bool = true,
               allowedKeys: String = "") {
     self.allowedKeys = allowedKeys
-    super.init(primaryFormat: primaryFormat, autocomplete: autocomplete, autocompleteOnFocus: autocompleteOnFocus, autoskip: autoskip, rightToLeft: rightToLeft, affineFormats: affineFormats, affinityCalculationStrategy: affinityCalculationStrategy, customNotations: customNotations, onMaskedTextChangedCallback: onMaskedTextChangedCallback, allowSuggestions: allowSuggestions)
+    super.init(
+      primaryFormat: primaryFormat,
+      autocomplete: autocomplete,
+      autocompleteOnFocus: autocompleteOnFocus,
+      autoskip: autoskip,
+      rightToLeft: rightToLeft,
+      affineFormats: affineFormats,
+      affinityCalculationStrategy: affinityCalculationStrategy,
+      customNotations: customNotations,
+      onMaskedTextChangedCallback: onMaskedTextChangedCallback,
+      allowSuggestions: allowSuggestions
+    )
   }
 
   override func textField(

--- a/ios/NotifyingAdvancedTexInputMaskListener.swift
+++ b/ios/NotifyingAdvancedTexInputMaskListener.swift
@@ -12,6 +12,21 @@ import UIKit
 class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
   public var allowedKeys = ""
 
+  public init(primaryFormat: String = "",
+              autocomplete: Bool = true,
+              autocompleteOnFocus: Bool = true,
+              autoskip: Bool = false,
+              rightToLeft: Bool = false,
+              affineFormats: [String] = [],
+              affinityCalculationStrategy: AffinityCalculationStrategy = .wholeString,
+              customNotations: [Notation] = [],
+              onMaskedTextChangedCallback: ((_ textInput: UITextInput, _ value: String, _ complete: Bool, _ tailPlaceholder: String) -> Void)? = nil,
+              allowSuggestions: Bool = true,
+              allowedKeys: String = "") {
+    self.allowedKeys = allowedKeys
+    super.init(primaryFormat: primaryFormat, autocomplete: autocomplete, autocompleteOnFocus: autocompleteOnFocus, autoskip: autoskip, rightToLeft: rightToLeft, affineFormats: affineFormats, affinityCalculationStrategy: affinityCalculationStrategy, customNotations: customNotations, onMaskedTextChangedCallback: onMaskedTextChangedCallback, allowSuggestions: allowSuggestions)
+  }
+
   override func textField(
     _ textField: UITextField,
     shouldChangeCharactersIn range: NSRange,

--- a/ios/NotifyingAdvancedTexInputMaskListener.swift
+++ b/ios/NotifyingAdvancedTexInputMaskListener.swift
@@ -26,7 +26,8 @@ class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
                  _ complete: Bool,
                  _ tailPlaceholder: String) -> Void)? = nil,
               allowSuggestions: Bool = true,
-              allowedKeys: String = "") {
+              allowedKeys: String = "")
+  {
     self.allowedKeys = allowedKeys
     super.init(
       primaryFormat: primaryFormat,

--- a/ios/NotifyingAdvancedTexInputMaskListener.swift
+++ b/ios/NotifyingAdvancedTexInputMaskListener.swift
@@ -22,8 +22,7 @@ class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
               customNotations: [Notation] = [],
               onMaskedTextChangedCallback: ((_ textInput: UITextInput, _ value: String, _ complete: Bool, _ tailPlaceholder: String) -> Void)? = nil,
               allowSuggestions: Bool = true,
-              allowedKeys: String = "")
-  {
+              allowedKeys: String = "") {
     self.allowedKeys = allowedKeys
     super.init(primaryFormat: primaryFormat, autocomplete: autocomplete, autocompleteOnFocus: autocompleteOnFocus, autoskip: autoskip, rightToLeft: rightToLeft, affineFormats: affineFormats, affinityCalculationStrategy: affinityCalculationStrategy, customNotations: customNotations, onMaskedTextChangedCallback: onMaskedTextChangedCallback, allowSuggestions: allowSuggestions)
   }

--- a/ios/NotifyingAdvancedTexInputMaskListener.swift
+++ b/ios/NotifyingAdvancedTexInputMaskListener.swift
@@ -22,7 +22,8 @@ class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
               customNotations: [Notation] = [],
               onMaskedTextChangedCallback: ((_ textInput: UITextInput, _ value: String, _ complete: Bool, _ tailPlaceholder: String) -> Void)? = nil,
               allowSuggestions: Bool = true,
-              allowedKeys: String = "") {
+              allowedKeys: String = "")
+  {
     self.allowedKeys = allowedKeys
     super.init(primaryFormat: primaryFormat, autocomplete: autocomplete, autocompleteOnFocus: autocompleteOnFocus, autoskip: autoskip, rightToLeft: rightToLeft, affineFormats: affineFormats, affinityCalculationStrategy: affinityCalculationStrategy, customNotations: customNotations, onMaskedTextChangedCallback: onMaskedTextChangedCallback, allowSuggestions: allowSuggestions)
   }

--- a/src/web/AdvancedTextInputMaskListener.ts
+++ b/src/web/AdvancedTextInputMaskListener.ts
@@ -24,6 +24,7 @@ class MaskedTextChangedListener {
   public autocomplete: boolean;
   public autoskip: boolean;
   public rightToLeft: boolean;
+  public textField: Field | null = null;
   public allowedKeys: string;
 
   private afterText: string = '';
@@ -52,7 +53,11 @@ class MaskedTextChangedListener {
     return this.maskGetOrCreate(this.primaryFormat, this.customNotations);
   }
 
-  public setText(field: Field, text: string, autocomplete?: boolean): void {
+  public setText(text: string, autocomplete?: boolean): void {
+    if (!this.textField) {
+      return;
+    }
+
     const useAutocomplete = autocomplete ?? this.autocomplete;
     const textAndCaret = new CaretString(text, text.length, {
       type: CaretGravityType.Forward,
@@ -61,15 +66,23 @@ class MaskedTextChangedListener {
     });
 
     const result: MaskResult = this.pickMask(textAndCaret).apply(textAndCaret);
-    field.value = result.formattedText.string;
+    this.textField.value = result.formattedText.string;
 
-    field.setSelectionRange(
+    this.textField.setSelectionRange(
       result.formattedText.caretPosition,
       result.formattedText.caretPosition
     );
 
     this.afterText = result.formattedText.string;
   }
+
+  public setAllowedKeys = (allowedKeys: string): void => {
+    this.allowedKeys = allowedKeys;
+
+    if (this.textField && allowedKeys) {
+      this.textField.value = '';
+    }
+  };
 
   public get placeholder(): string {
     return this.primaryMask.placeholder();
@@ -90,6 +103,10 @@ class MaskedTextChangedListener {
   public get totalValueLength(): number {
     return this.primaryMask.totalValueLength();
   }
+
+  public setTextField = (textField: Field): void => {
+    this.textField = textField;
+  };
 
   public handleTextChange = (
     event: NativeSyntheticEvent<TextInputChangeEventData>

--- a/src/web/AdvancedTextInputMaskListener.ts
+++ b/src/web/AdvancedTextInputMaskListener.ts
@@ -58,8 +58,12 @@ class MaskedTextChangedListener {
       return;
     }
 
+    const newText = this.allowedKeys
+      ? [...text].filter((char) => this.allowedKeys.includes(char)).join('')
+      : text;
+
     const useAutocomplete = autocomplete ?? this.autocomplete;
-    const textAndCaret = new CaretString(text, text.length, {
+    const textAndCaret = new CaretString(newText, newText.length, {
       type: CaretGravityType.Forward,
       autocomplete: useAutocomplete,
       autoskip: false,
@@ -80,7 +84,7 @@ class MaskedTextChangedListener {
     this.allowedKeys = allowedKeys;
 
     if (this.textField && allowedKeys) {
-      this.textField.value = '';
+      this.setText(this.textField.value, false);
     }
   };
 

--- a/src/web/hooks/useMaskedTextInputListener/index.ts
+++ b/src/web/hooks/useMaskedTextInputListener/index.ts
@@ -29,6 +29,8 @@ const useMaskedTextInputListener = ({
     formatted: string;
   }>({ extracted: '', formatted: '' });
 
+  const isInitialMount = useRef(true);
+
   const [listener] = useState<MaskedTextChangedListener>(
     () =>
       new MaskedTextChangedListener(
@@ -44,6 +46,12 @@ const useMaskedTextInputListener = ({
   );
 
   useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+
+      return;
+    }
+
     if (listener.affineFormats !== affinityFormat && affinityFormat) {
       listener.affineFormats = affinityFormat;
     }
@@ -72,7 +80,7 @@ const useMaskedTextInputListener = ({
     }
 
     if (listener.allowedKeys !== allowedKeys) {
-      listener.allowedKeys = allowedKeys;
+      listener.setAllowedKeys(allowedKeys);
     }
 
     if (listener.rightToLeft !== isRTL) {
@@ -139,10 +147,12 @@ const useMaskedTextInputListener = ({
   );
 
   return {
+    setTextField: listener.setTextField,
     handleOnChange,
     handleFocus,
     listener,
     defaultValue: defaultValueResult,
+    inputRef: listener.textField,
   };
 };
 

--- a/src/web/views/MaskedTextInput/index.tsx
+++ b/src/web/views/MaskedTextInput/index.tsx
@@ -1,9 +1,9 @@
 import { TextInput } from 'react-native';
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useImperativeHandle, useRef } from 'react';
 import type { MaskedTextInputProps } from '../../../types';
 import useMaskedTextInputListener from '../../hooks/useMaskedTextInputListener';
 
-const MaskedTextInput = forwardRef<TextInput, MaskedTextInputProps>(
+const MaskedTextInput = forwardRef<TextInput | null, MaskedTextInputProps>(
   (
     {
       affinityCalculationStrategy,
@@ -24,10 +24,13 @@ const MaskedTextInput = forwardRef<TextInput, MaskedTextInputProps>(
     },
     ref
   ) => {
+    const inputRef = useRef<TextInput>(null);
+
     const {
       defaultValue: maskedDefaultValue,
       handleFocus,
       handleOnChange,
+      setTextField,
     } = useMaskedTextInputListener({
       mask,
       affinityFormat,
@@ -44,9 +47,19 @@ const MaskedTextInput = forwardRef<TextInput, MaskedTextInputProps>(
       defaultValue,
     });
 
+    useImperativeHandle<TextInput | null, TextInput | null>(
+      ref,
+      () => {
+        setTextField(inputRef.current as unknown as HTMLInputElement);
+
+        return inputRef.current;
+      },
+      [setTextField, inputRef]
+    );
+
     return (
       <TextInput
-        ref={ref}
+        ref={inputRef}
         autoCapitalize={autoCapitalize}
         defaultValue={maskedDefaultValue}
         onChange={handleOnChange}


### PR DESCRIPTION
## 📜 Description
Currently, if you try to dynamically change the allowedKeys parameter, the value of the text is the same as it was before the parameter was updated. I think this is wrong behaviour and we should update the text when we change allowedKeys.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added ref handling logic
- added reset 

### iOS

- moved initialization of allowedKeys to constructor method
- added logic for updating text when allowedKeys changed

### Android

- added logic for updating text when allowedKeys changed

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

web(chrome browser)

iPhone 15 pro simulator

Pixel 6a emulator

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### iOS

https://github.com/user-attachments/assets/20e65605-d685-4e2f-9bd7-79de3d7feed4


### Android

https://github.com/user-attachments/assets/37d49fe0-9733-4051-9019-53f0aca76868

### Web

https://github.com/user-attachments/assets/2ce1144c-ea38-4cf3-8ec1-fcb2775ae978


## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed