### PR TITLE
fix: default value is not set during re-renders/unmount

### DIFF
--- a/example/src/navigation/Root/index.tsx
+++ b/example/src/navigation/Root/index.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import ScreenNames from '../screenNames';
 import Main from '../../screens/Main';
 import RNTextInput from '../../screens/RNTextInput';
+import Date from '../../screens/Date';
 
 const RootStack = createNativeStackNavigator({
   initialRouteName: ScreenNames.Main,
@@ -11,6 +12,9 @@ const RootStack = createNativeStackNavigator({
     },
     [ScreenNames.RNTextInput]: {
       screen: RNTextInput,
+    },
+    [ScreenNames.Date]: {
+      screen: Date,
     },
   },
 });

--- a/example/src/navigation/screenNames.ts
+++ b/example/src/navigation/screenNames.ts
@@ -1,5 +1,6 @@
 const enum ScreenNames {
   Main = 'Main',
+  Date = 'Date',
   RNTextInput = 'RNTextInput',
 }
 

--- a/example/src/screens/Date/index.tsx
+++ b/example/src/screens/Date/index.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+import { ScrollView } from 'react-native';
+import { MaskedTextInput } from 'react-native-advanced-input-mask';
+import styles from './styles';
+
+const affineFormats = ['[00]{/}[00]{/}[0000]'];
+
+const DateScreen = () => {
+  console.log(new Date().toISOString());
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <MaskedTextInput
+        defaultValue={new Date().toISOString()}
+        style={styles.maskedTextInput}
+        mask="[0000]{/}[00]{/}[00]"
+        affinityFormat={affineFormats}
+        autocomplete={false}
+        allowSuggestions={true}
+        autocompleteOnFocus={false}
+        autoSkip={false}
+      />
+    </ScrollView>
+  );
+};
+
+export default DateScreen;

--- a/example/src/screens/Date/styles.ts
+++ b/example/src/screens/Date/styles.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  maskedTextInput: {
+    width: '100%',
+    height: 50,
+    backgroundColor: 'lightgray',
+  },
+});
+
+export default styles;

--- a/example/src/screens/Main/index.tsx
+++ b/example/src/screens/Main/index.tsx
@@ -23,8 +23,8 @@ const Main = () => {
   const inputRef = React.useRef<TextInput>(null);
 
   const [textState, setTextState] = React.useState({
-    extracted: '',
-    formatted: '',
+    extracted: '0000',
+    formatted: '00-00',
   });
 
   const [focused, setFocused] = React.useState(false);
@@ -59,6 +59,10 @@ const Main = () => {
     reset({ index: 0, routes: [{ name: ScreenNames.RNTextInput }] });
   }, [reset]);
 
+  const navigateToDateScreen = React.useCallback(() => {
+    navigate(ScreenNames.Date);
+  }, [navigate]);
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text>extracted value {textState.extracted}</Text>
@@ -66,7 +70,6 @@ const Main = () => {
       <Text>focused {focused ? 'Yes' : 'No'}</Text>
       <MaskedTextInput
         ref={inputRef}
-        defaultValue="0000"
         value={textState.formatted}
         onFocus={onFocus}
         onBlur={onBlur}
@@ -89,6 +92,10 @@ const Main = () => {
       <Button
         title="Navigate to RN text input screen with reset"
         onPress={navigateToRNTextInputWithReset}
+      />
+      <Button
+        title="Navigate to screen with date mask"
+        onPress={navigateToDateScreen}
       />
     </ScrollView>
   );

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -25,7 +25,6 @@ class AdvancedTextInputMaskDecoratorView: UIView {
   private var maskInputListener: NotifyingAdvancedTexInputMaskListener?
   private var lastDispatchedEvent: [String: String] = [:]
   private var textFieldDelegate: UITextFieldDelegate?
-  private var isInitialMount = true
   private weak var originalTextFieldDelegate: UITextFieldDelegate?
 
   @objc private var primaryMaskFormat: NSString = "" {

--- a/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -21,11 +21,12 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   // MARK: - Private Properties
 
-  private weak var textField: UITextField?
+  private var textField: UITextField?
   private var maskInputListener: NotifyingAdvancedTexInputMaskListener?
   private var lastDispatchedEvent: [String: String] = [:]
   private var textFieldDelegate: UITextFieldDelegate?
   private var isInitialMount = true
+  private weak var originalTextFieldDelegate: UITextFieldDelegate?
 
   @objc private var primaryMaskFormat: NSString = "" {
     didSet {
@@ -105,8 +106,9 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     }
   }
 
-  @objc private var value: NSString = "" {
+  @objc private var value: NSString? {
     didSet {
+      guard let value = value else { return }
       updateTextWithoutNotification(text: value as String)
     }
   }
@@ -138,7 +140,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
   // MARK: - Utility Methods
 
   @objc private func updateTextWithoutNotification(text: String) {
-    if text == textField?.allText {
+    if text == textField?.attributedText?.string {
       return
     }
 
@@ -150,7 +152,9 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     )
     let result = primaryMask.apply(toText: caretString)
 
-    textField?.allText = result.formattedText.string
+    let attributedText = NSAttributedString(string: result.formattedText.string)
+
+    textField?.attributedText = attributedText
   }
 
   @objc private func maybeUpdateText(text: String) {
@@ -181,7 +185,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
   private func configureTextField() {
     findTextField()
     guard let textField = textField else { return }
-
+    originalTextFieldDelegate = textField.delegate
     textFieldDelegate = AdvancedInputMaskDelegateWrapper(textFieldDelegate: textField.delegate)
     textField.delegate = textFieldDelegate
   }
@@ -213,24 +217,22 @@ class AdvancedTextInputMaskDecoratorView: UIView {
   }
 
   @objc func cleanup() {
+    textField?.delegate = originalTextFieldDelegate
     textField = nil
     maskInputListener?.textFieldDelegate = nil
     maskInputListener = nil
+    originalTextFieldDelegate = nil
+    textFieldDelegate = nil
   }
 
   // MARK: - View Lifecycle
 
-  override func didMoveToWindow() {
-    if textField == nil {
+  override func willMove(toWindow newWindow: UIWindow?) {
+    super.willMove(toWindow: newWindow)
+    if textField == nil, newWindow != nil {
       configureTextField()
       configureMaskInputListener()
-
-      if isInitialMount {
-        // reset the initial text before setting the default value
-        textField?.allText = ""
-        updateTextWithoutNotification(text: defaultValue as String)
-        isInitialMount = false
-      }
+      updateTextWithoutNotification(text: value as? String ?? defaultValue as String)
     }
   }
 }

--- a/ios/AdvancedtextInputMaskDecoratorView.mm
+++ b/ios/AdvancedtextInputMaskDecoratorView.mm
@@ -55,10 +55,9 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle
 {
-  [super prepareForRecycle];
   [_view cleanup];
-  _view.delegate = nil;
-  _view = nil;
+
+  [super prepareForRecycle];
 }
 
 #pragma mark - RCTComponentViewProtocol


### PR DESCRIPTION
## 📜 Description
I found that during unmounts or re-renders of the text input component, the default value (which is provided from JavaScript) is lost. This issue arises due to the current behavior in the AdvancedTextInputMaskDecoratorView Objective-C file. When the view is being prepared for recycling, we incorrectly reset the view to nil and also reset the delegate, which causes the default value to be lost.

## 💡 Motivation and Context

Fix problem with defaultValue on iOS

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added new JS screen Date
-

### iOS

- fixed default value
- added more logic for clean up
- started using attributed text instead of all text

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro simulator

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

#### Old arch:

https://github.com/user-attachments/assets/df5da0d7-6191-424a-b995-762b1bca74d2

#### New arch:

https://github.com/user-attachments/assets/0919a85a-ca35-46bd-9043-4e5695d6aed9

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed