### PR TITLE
fix: initial value for controlled text inputs for android

### DIFF
--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -29,6 +29,7 @@ class AdvancedTextInputMaskDecoratorView(
   private var maskedTextChangeListener: ReactMaskedTextChangeListener? = null
   private var allowedKeys: String? = null
   private var defaultValue: String? = null
+  private var value: String? = null
   private var isInitialMount = true
 
   private val valueListener =
@@ -44,7 +45,8 @@ class AdvancedTextInputMaskDecoratorView(
   }
 
   private fun applyDefaultValue() {
-    defaultValue?.let { maskedTextChangeListener?.setText(it, false) }
+    val nextDefaultValue = value ?: defaultValue
+    nextDefaultValue?.let { maskedTextChangeListener?.setText(it, false) }
   }
 
   override fun onAttachedToWindow() {
@@ -138,6 +140,7 @@ class AdvancedTextInputMaskDecoratorView(
   }
 
   fun setValue(value: String?) {
+    this.value = value
     if (textField?.text.toString() != value) {
       value?.let { maskedTextChangeListener?.setText(it) }
     }


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

I want to fix the behaviour of the initial value for controlled text inputs, right now it works like this: 
we have defaultValue -> insert it. 
But according to web React rules, defaultValue is only needed for uncontrolled text inputs. So the logic should be like this:
we have a value?
 yes, we insert it as defaultValue, 
 no, we make a fallback to defaultValue.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Text inputs behavior must be the same across all of the platforms. 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

- added logic to set default value
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Android Pixel 6 API 34

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

https://github.com/user-attachments/assets/d8cd8b72-b963-40ae-923b-f5434c429690



## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed