### PR TITLE
feat: add validationRegex prop

### DIFF
--- a/.github/workflows/verify-ios.yml
+++ b/.github/workflows/verify-ios.yml
@@ -39,7 +39,7 @@ jobs:
         run: brew install swiftformat
 
       - name: Format Swift code
-        run: swiftformat --verbose ./package/ios
+        run: swiftformat --verbose .
 
       - name: Verify that the formatted code hasn't been changed
         run: git diff --exit-code HEAD

--- a/.github/workflows/verify-ios.yml
+++ b/.github/workflows/verify-ios.yml
@@ -39,7 +39,7 @@ jobs:
         run: brew install swiftformat
 
       - name: Format Swift code
-        run: swiftformat --verbose .
+        run: swiftformat --verbose ./package/ios
 
       - name: Verify that the formatted code hasn't been changed
         run: git diff --exit-code HEAD

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ For applications requiring conditional or more complex formatting, this package 
 | `mask`                        | `string`                             | The mask format to be applied to the text input, defining the pattern for formatting. Example: `"[0000] [0000] [0000] [0000]"`.               |
 | `customNotations`             | `Notation[]`                         | Array of custom notations for the mask format. Each notation object includes: `character`, `characterSet`, and `isOptional`.                  |
 | `allowedKeys`                  |`string`                              | A string specifying the characters that are permitted for input.                                                         |
+| `validationRegex`                  |`regex string`                              |  A validation regex that runs before applying the mask.                                                         |
 | `onChangeText`                | `(formatted: string, extracted: string) => void` | Callback function triggered on text change. Receives `formattedValue` (with mask) and `extractedValue` (raw input).                        |
 | `onTailPlaceholderChange`     | `(tailPlaceholder: string) => void`  | Callback function called when the tail placeholder changes, receiving the updated `tailPlaceholder` value.                                    |
 | `affinityFormat`              | `string[]`                           | Array of strings for affinity format, used to determine the best mask format based on the input.                                              |

--- a/apps/example/ios/MaskedTextInputExample/AppDelegate.swift
+++ b/apps/example/ios/MaskedTextInputExample/AppDelegate.swift
@@ -1,30 +1,30 @@
-import UIKit
 import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
- 
+import UIKit
+
 @main
 class AppDelegate: RCTAppDelegate {
-  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    self.moduleName = "MaskedTextInputExample"
-    self.dependencyProvider = RCTAppDependencyProvider()
- 
-    // You can add your custom initial props in the dictionary below.
-    // They will be passed down to the ViewController used by React Native.
-    self.initialProps = ["test": "value"]
- 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
- 
-  override func sourceURL(for bridge: RCTBridge) -> URL? {
-    self.bundleURL()
-  }
- 
-  override func bundleURL() -> URL? {
-#if DEBUG
-    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
-#else
-    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
-#endif
-  }
+    override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        moduleName = "MaskedTextInputExample"
+        dependencyProvider = RCTAppDependencyProvider()
+
+        // You can add your custom initial props in the dictionary below.
+        // They will be passed down to the ViewController used by React Native.
+        initialProps = [:]
+
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    override func sourceURL(for _: RCTBridge) -> URL? {
+        bundleURL()
+    }
+
+    override func bundleURL() -> URL? {
+        #if DEBUG
+            RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+        #else
+            Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+        #endif
+    }
 }

--- a/apps/example/src/navigation/Root/index.tsx
+++ b/apps/example/src/navigation/Root/index.tsx
@@ -8,6 +8,7 @@ import IBAN from '../../screens/IBAN';
 import AllowedKeys from '../../screens/AllowedKeys';
 import CustomNotations from '../../screens/CustomNotations';
 import ControlledInput from '../../screens/ControlledInput';
+import ValidationRegex from '../../screens/ValidationRegEx';
 
 const RootStack = createNativeStackNavigator({
   initialRouteName: ScreenNames.Main,
@@ -58,6 +59,12 @@ const RootStack = createNativeStackNavigator({
         title: 'Controlled Input 🕹',
       },
       screen: ControlledInput,
+    },
+    [ScreenNames.ValidationRegex]: {
+      options: {
+        title: 'Validation Regex 🧪',
+      },
+      screen: ValidationRegex,
     },
   },
 });

--- a/apps/example/src/navigation/screenNames.ts
+++ b/apps/example/src/navigation/screenNames.ts
@@ -7,6 +7,7 @@ const enum ScreenNames {
   IBAN = 'IBAN',
   ControlledInput = 'ControlledInput',
   AllowedKeys = 'AllowedKeys',
+  ValidationRegex = 'ValidationRegex',
 }
 
 export default ScreenNames;

--- a/apps/example/src/screens/Main/constants.ts
+++ b/apps/example/src/screens/Main/constants.ts
@@ -38,4 +38,10 @@ export const MENU_ITEMS: Omit<MenuItemProps<ScreenNames>, 'onPress'>[] = [
     testId: 'controlled-text-input',
     emoji: '🕹',
   },
+  {
+    title: 'Validation Regex',
+    info: ScreenNames.ValidationRegex,
+    testId: 'validation-regex',
+    emoji: '🧪',
+  },
 ];

--- a/apps/example/src/screens/ValidationRegEx/index.tsx
+++ b/apps/example/src/screens/ValidationRegEx/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ScrollView } from 'react-native';
+import TextInput from '../../components/TextInput';
+import styles from './styles';
+
+const ValidationRegex = () => {
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <TextInput
+        mask="[09999999].[00]"
+        validationRegex={'^(?!.*[.,].*[.,])\\d*(?:[.,]\\d{0,2})?$'}
+        keyboardType="decimal-pad"
+      />
+    </ScrollView>
+  );
+};
+
+export default ValidationRegex;

--- a/apps/example/src/screens/ValidationRegEx/styles.ts
+++ b/apps/example/src/screens/ValidationRegEx/styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flexShrink: 0,
+  },
+  contentContainer: {
+    paddingVertical: 20,
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default styles;

--- a/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
+++ b/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
@@ -39,7 +39,6 @@ class ReactMaskedTextChangeListener(
     val newText = allowedKeys?.run { text.filter { it in this } } ?: text
     val validationRegex = this.validationRegex
     if (validationRegex != null && !Regex(validationRegex).matches(text)) {
-      field.setSelection(cursorPosition)
       return
     }
 

--- a/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
+++ b/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
@@ -13,11 +13,12 @@ class ReactMaskedTextChangeListener(
   affinityCalculationStrategy: AffinityCalculationStrategy,
   autocomplete: Boolean,
   autoSkip: Boolean,
-  field: ReactEditText,
+  val field: ReactEditText,
   rightToLeft: Boolean,
   valueListener: MaskedTextValueListener,
   var allowedKeys: String?,
   private val focusChangeListener: View.OnFocusChangeListener,
+  var validationRegex: String?,
 ) : MaskedTextChangedListener(
     primaryFormat = primaryFormat,
     affineFormats = affineFormats,
@@ -36,6 +37,12 @@ class ReactMaskedTextChangeListener(
     count: Int,
   ) {
     val newText = allowedKeys?.run { text.filter { it in this } } ?: text
+    val validationRegex = this.validationRegex
+    if (validationRegex != null && !Regex(validationRegex).matches(text)) {
+      field.setSelection(cursorPosition)
+      return
+    }
+
     super.onTextChanged(newText, cursorPosition, before, count)
   }
 
@@ -59,6 +66,7 @@ class ReactMaskedTextChangeListener(
       rightToLeft: Boolean = false,
       valueListener: MaskedTextValueListener,
       allowedKeys: String?,
+      validationRegex: String?,
     ): ReactMaskedTextChangeListener {
       val listener =
         ReactMaskedTextChangeListener(
@@ -73,6 +81,7 @@ class ReactMaskedTextChangeListener(
           focusChangeListener = field.onFocusChangeListener,
           valueListener = valueListener,
           allowedKeys = allowedKeys,
+          validationRegex = validationRegex,
         )
       field.addTextChangedListener(listener)
       field.onFocusChangeListener = listener

--- a/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
+++ b/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
@@ -141,6 +141,13 @@ class AdvancedTextInputMaskDecoratorViewManager(
   ) {
   }
 
+  override fun setValidationRegex(
+    view: AdvancedTextInputMaskDecoratorView,
+    validationRegex: String?,
+  ) {
+    view.setValidationRegex(validationRegex)
+  }
+
   companion object {
     const val NAME = "AdvancedTextInputMaskDecoratorView"
   }

--- a/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
+++ b/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
@@ -121,6 +121,14 @@ class AdvancedTextInputMaskDecoratorViewManager(
     view.setAllowedKeys(allowedKeys)
   }
 
+  @ReactProp(name = "validationRegex")
+  override fun setValidationRegex(
+    view: AdvancedTextInputMaskDecoratorView,
+    validationRegex: String?,
+  ) {
+    view.setValidationRegex(validationRegex)
+  }
+
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     val export = super.getExportedCustomDirectEventTypeConstants() ?: newHashMap()
 
@@ -139,13 +147,6 @@ class AdvancedTextInputMaskDecoratorViewManager(
     view: AdvancedTextInputMaskDecoratorView?,
     value: Boolean,
   ) {
-  }
-
-  override fun setValidationRegex(
-    view: AdvancedTextInputMaskDecoratorView,
-    validationRegex: String?,
-  ) {
-    view.setValidationRegex(validationRegex)
   }
 
   companion object {

--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -31,6 +31,7 @@ class AdvancedTextInputMaskDecoratorView(
   private var defaultValue: String? = null
   private var value: String? = null
   private var isInitialMount = true
+  private var validationRegex: String? = null
 
   private val valueListener =
     MaskedTextValueListener { _, extracted, formatted, tailPlaceholder ->
@@ -81,6 +82,7 @@ class AdvancedTextInputMaskDecoratorView(
             affineFormats = affineFormats,
             affinityCalculationStrategy = affinityCalculationStrategy,
             allowedKeys = allowedKeys,
+            validationRegex = validationRegex,
           )
 
         if (isInitialMount) {
@@ -157,6 +159,11 @@ class AdvancedTextInputMaskDecoratorView(
       }
 
     textField?.transformationMethod = customTransformationMethod
+  }
+
+  fun setValidationRegex(validationRegex: String?) {
+    this.validationRegex = validationRegex
+    maskedTextChangeListener?.validationRegex = validationRegex
   }
 
   fun setAllowedKeys(allowedKeys: String?) {

--- a/package/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
+++ b/package/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
@@ -70,4 +70,9 @@ abstract class AdvancedTextInputMaskDecoratorViewManagerSpec<T : View> : SimpleV
     view: T?,
     value: Boolean,
   )
+
+  abstract fun setValidationRegex(
+    view: T,
+    value: String?,
+  )
 }

--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -112,6 +112,12 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     }
   }
 
+  @objc private var validationRegex: NSString? {
+    didSet {
+      maskInputListener?.validationRegex = validationRegex as? String
+    }
+  }
+
   // MARK: - Event Handlers
 
   private func onAdvancedMaskTextChangedCallback(
@@ -209,7 +215,8 @@ class AdvancedTextInputMaskDecoratorView: UIView {
         )
       },
       allowSuggestions: allowSuggestions,
-      allowedKeys: (allowedKeys ?? "") as String
+      allowedKeys: (allowedKeys ?? "") as String,
+      validationRegex: validationRegex as? String
     )
     maskInputListener?.textFieldDelegate = textFieldDelegate
     textField.delegate = maskInputListener

--- a/package/ios/AdvancedTextInputViewContainer.h
+++ b/package/ios/AdvancedTextInputViewContainer.h
@@ -30,5 +30,6 @@
 - (void)setValue:(NSString *)value;
 - (void)setAffinityFormat:(NSArray<NSString *> *)affinityFormat;
 - (void)setAffinityCalculationStrategy:(NSInteger)affinityCalculationStrategy;
+- (void)setValidationRegex:(NSString *)validationRegex;
 - (void)cleanup;
 @end

--- a/package/ios/AdvancedtextInputMaskDecoratorView.mm
+++ b/package/ios/AdvancedtextInputMaskDecoratorView.mm
@@ -124,6 +124,10 @@ using namespace facebook::react;
     [_view setAffinityCalculationStrategy:newViewProps.affinityCalculationStrategy];
   }
 
+  if (newViewProps.validationRegex != oldViewProps.validationRegex) {
+    [_view setValidationRegex:RCTNSStringFromString(newViewProps.validationRegex)];
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/package/ios/MaskedTextInputManager.mm
+++ b/package/ios/MaskedTextInputManager.mm
@@ -13,6 +13,7 @@ RCT_EXPORT_VIEW_PROPERTY(autocompleteOnFocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowSuggestions, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(defaultValue, NSString)
 RCT_EXPORT_VIEW_PROPERTY(value, NSString)
+RCT_EXPORT_VIEW_PROPERTY(validationRegex, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(onAdvancedMaskTextChange, RCTDirectEventBlock);
 @end

--- a/package/src/native/specs/AdvancedTextInputMaskDecoratorViewNativeComponent.ts
+++ b/package/src/native/specs/AdvancedTextInputMaskDecoratorViewNativeComponent.ts
@@ -47,6 +47,7 @@ export interface NativeProps extends ViewProps {
   onAdvancedMaskTextChange?: DirectEventHandler<OnAdvancedMaskTextChange>;
   primaryMaskFormat: string;
   value?: string;
+  validationRegex?: string;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/package/src/native/views/MaskedTextInput/index.tsx
+++ b/package/src/native/views/MaskedTextInput/index.tsx
@@ -25,7 +25,6 @@ const MaskedTextInput = forwardRef<TextInput, MaskedTextInputProps>(
       autoSkip,
       customNotations,
       customTransformation,
-      allowedKeys,
       defaultValue,
       isRTL,
       mask,
@@ -34,6 +33,7 @@ const MaskedTextInput = forwardRef<TextInput, MaskedTextInputProps>(
       onChangeText,
       onTailPlaceholderChange,
       renderTextInputComponent,
+      validationRegex,
       ...rest
     },
     ref
@@ -61,12 +61,12 @@ const MaskedTextInput = forwardRef<TextInput, MaskedTextInputProps>(
           autoSkip={autoSkip}
           customNotations={customNotations}
           customTransformation={customTransformation}
-          allowedKeys={allowedKeys}
           defaultValue={defaultValue}
           isRTL={isRTL}
           onAdvancedMaskTextChange={onAdvancedMaskTextChangeCallback}
           primaryMaskFormat={mask}
           style={IS_FABRIC ? styles.farAway : styles.displayNone}
+          validationRegex={validationRegex}
           value={value}
         />
       </>

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -94,6 +94,12 @@ export type MaskedTextInputOwnProps = {
   renderTextInputComponent?:
     | ElementType
     | ((props: TextInputProps) => JSX.Element);
+  /**
+   * A validation regex that runs before applying the mask.
+   *
+   * ⚠️ Use this only when absolutely necessary. Prefer using `allowedKeys` with `affinityFormat` instead.
+   */
+  validationRegex?: string;
 };
 
 export type MaskedTextInputProps = Omit<TextInputProps, 'onChangeText'> &

--- a/package/src/web/hooks/useMaskedTextInputListener/index.ts
+++ b/package/src/web/hooks/useMaskedTextInputListener/index.ts
@@ -23,6 +23,7 @@ const useMaskedTextInputListener = ({
   onTailPlaceholderChange,
   onFocus,
   defaultValue,
+  validationRegex,
 }: Props) => {
   const prevDispatchedPayload = useRef<{
     extracted: string;
@@ -41,7 +42,8 @@ const useMaskedTextInputListener = ({
         autocomplete,
         autoSkip,
         isRTL,
-        allowedKeys
+        allowedKeys,
+        validationRegex
       )
   );
 
@@ -86,7 +88,12 @@ const useMaskedTextInputListener = ({
     if (listener.rightToLeft !== isRTL) {
       listener.rightToLeft = isRTL;
     }
+
+    if (listener.validationRegex !== validationRegex) {
+      listener.validationRegex = validationRegex;
+    }
   }, [
+    validationRegex,
     affinityFormat,
     customNotations,
     mask,

--- a/package/src/web/views/MaskedTextInput/index.tsx
+++ b/package/src/web/views/MaskedTextInput/index.tsx
@@ -21,6 +21,7 @@ const MaskedTextInput = forwardRef<TextInput | null, MaskedTextInputProps>(
       onTailPlaceholderChange,
       onFocus,
       renderTextInputComponent,
+      validationRegex,
       ...rest
     },
     ref
@@ -47,6 +48,7 @@ const MaskedTextInput = forwardRef<TextInput | null, MaskedTextInputProps>(
       onChangeText,
       onTailPlaceholderChange,
       onFocus,
+      validationRegex,
       defaultValue,
     });
 


### PR DESCRIPTION
## 📜 Description
This world isn't always perfect and sometimes we have to make up new stuff to cover something that doesn't quite make sense. So I introduce a new property: validationRegex, with this property we can do away with allowedKeys completely, because we can validate them via regex, also we can specify the exact position of separators like points.


<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I want to handle all formatting/allowing/pre-validation logic in one prop

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- validationRegex prop

### iOS

- validationRegex prop
-

### Android

- validationRegex prop
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro simulator

Pixel 6a emulator

Chrome browser

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### iOS

https://github.com/user-attachments/assets/264d9332-2777-4e75-b934-4ff9ae32237d

### Android

https://github.com/user-attachments/assets/186ad36a-cb03-4d8e-8efc-479fc0ccf063


### Web

https://github.com/user-attachments/assets/967dc158-9cac-4c05-82ee-ec5593fbaaa9


## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed