### PR TITLE
feat: android paper build on CI

### DIFF
--- a/.github/workflows/build-android-paper.yml
+++ b/.github/workflows/build-android-paper.yml
@@ -1,0 +1,47 @@
+name: 🤖 Build Android paper
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/build-android-paper.yml"
+      - "package/android/**"
+      - "apps/example/android/**"
+      - "yarn.lock"
+      - "apps/example/yarn.lock"
+  pull_request:
+    paths:
+      - ".github/workflows/build-android-paper.yml"
+      - "package/android/**"
+      - "example/android/**"
+      - "yarn.lock"
+      - "apps/example/yarn.lock"
+
+jobs:
+  build-android:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup
+          uses: ./.github/actions/setup
+
+        - name: Setup JDK 17
+          uses: actions/setup-java@v4
+          with:
+            distribution: "microsoft"
+            java-version: "17"
+
+        - name: Restore Gradle cache
+          uses: actions/cache@v4
+          with:
+            path: |
+              ~/.gradle/caches
+              ~/.gradle/wrapper
+            key: ${{ runner.os }}-gradle-paper-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+            restore-keys: |
+              ${{ runner.os }}-gradle-paper
+        - name: Build example for Android
+          run: cd apps/example/android && sed -i -e 's/^newArchEnabled=.*/newArchEnabled=false/' gradle.properties && ./gradlew assembleDebug --build-cache && cd ../..


### PR DESCRIPTION
## 📜 Description
I want to expand my CI and have a paper build of android to ensure my package will work on the old arch as well.
<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

better old arch support

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

new android-paper-build

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested on CI

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed