### PR TITLE
fix: android build warnings

### DIFF
--- a/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
+++ b/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
@@ -3,8 +3,6 @@ package com.maskedtextinput.managers
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.common.MapBuilder
-import com.facebook.react.common.MapBuilder.newHashMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.maskedtextinput.AdvancedTextInputMaskDecoratorViewManagerSpec
@@ -23,10 +21,10 @@ class AdvancedTextInputMaskDecoratorViewManager(
   @ReactProp(name = "primaryMaskFormat")
   override fun setPrimaryMaskFormat(
     view: AdvancedTextInputMaskDecoratorView,
-    value: String?,
+    mask: String?,
   ) {
-    if (value != null) {
-      view.setMask(value)
+    if (mask != null) {
+      view.setMask(mask)
     }
   }
 
@@ -130,9 +128,9 @@ class AdvancedTextInputMaskDecoratorViewManager(
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
-    val export = super.getExportedCustomDirectEventTypeConstants() ?: newHashMap()
+    val export = super.getExportedCustomDirectEventTypeConstants() ?: hashMapOf()
 
-    export[EventNames.CHANGE_TEXT_EVENT] = MapBuilder.of("registrationName", "onAdvancedMaskTextChange")
+    export[EventNames.CHANGE_TEXT_EVENT] = mapOf("registrationName" to "onAdvancedMaskTextChange")
 
     return export
   }

--- a/package/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
+++ b/package/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
@@ -73,6 +73,6 @@ abstract class AdvancedTextInputMaskDecoratorViewManagerSpec<T : View> : SimpleV
 
   abstract fun setValidationRegex(
     view: T,
-    value: String?,
+    validationRegex: String?,
   )
 }


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

I want to fix warnings that are logged during build phase in the android console.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

warnings sometimes cause questions for some developers and sometimes it's hard to understand what went wrong

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- migrated from MapBuilder to mapOf
- aligned param names with abstract class param names in some methods

### Android

- migrated from MapBuilder to mapOf
- aligned param names with abstract class

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested locally and on CI

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed