### PR TITLE
fix: selection logic on android and web platforms

### DIFF
--- a/apps/example/src/screens/ValidationRegEx/index.tsx
+++ b/apps/example/src/screens/ValidationRegEx/index.tsx
@@ -11,6 +11,7 @@ const ValidationRegex = () => {
     >
       <TextInput
         mask="[09999999].[00]"
+        allowedKeys="0123456789,."
         validationRegex={'^(?!.*[.,].*[.,])\\d*(?:[.,]\\d{0,2})?$'}
         keyboardType="decimal-pad"
       />

--- a/package/src/web/AdvancedTextInputMaskListener.ts
+++ b/package/src/web/AdvancedTextInputMaskListener.ts
@@ -62,11 +62,7 @@ class MaskedTextChangedListener {
     }
 
     const newText = this.prepareText(text);
-    console.log(this.validationRegex);
-    if (
-      this.validationRegex &&
-      !new RegExp(this.validationRegex).test(newText)
-    ) {
+    if (!this.isValidText(text)) {
       return;
     }
 
@@ -145,10 +141,7 @@ class MaskedTextChangedListener {
     };
     const newText = this.prepareText(text);
 
-    if (
-      this.validationRegex &&
-      !new RegExp(this.validationRegex).test(newText)
-    ) {
+    if (!this.isValidText(text)) {
       const textAndCaret = new CaretString(this.afterText, caretPosition, {
         type: CaretGravityType.Backward,
         autocomplete: false,
@@ -194,6 +187,9 @@ class MaskedTextChangedListener {
           .join('')
       : text;
   };
+
+  private isValidText = (text: string): boolean =>
+    this.validationRegex ? new RegExp(this.validationRegex).test(text) : true;
 
   handleFocus = (
     event: NativeSyntheticEvent<TextInputFocusEventData>


### PR DESCRIPTION
## 📜 Description
I had a lot of ideas how do I need to implement it, I thought about `onRegexValidationFailed` prop from the JS side, but my final solution is just to align this logic between platforms. If someone asks me to add an `onRegexValidationFailed` property, I would be happy to do so. However, I don't see any point in it right now.
<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I want to have one behavior for each platform.


## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Pixel 6a Emulator

Chrome browser

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### Before

https://github.com/user-attachments/assets/0723b4ba-83cb-4bdb-91c1-549dfb01f1cb

https://github.com/user-attachments/assets/70e3bf9e-e746-4d87-8cda-35cc8bc2b42c

### After

https://github.com/user-attachments/assets/375113e8-06b9-4758-a7c8-925c101c1294

https://github.com/user-attachments/assets/b3bb7cb3-1085-4662-a7b2-efa0a493187e



## 📝 Checklist

- [X] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed