### PR TITLE
fix: dont create validation regex every time when user changes text

### DIFF
--- a/apps/example/src/screens/Phone/index.tsx
+++ b/apps/example/src/screens/Phone/index.tsx
@@ -29,7 +29,6 @@ const Phone = () => {
         placeholder="+1 (000) 000-0000"
         mask="+1 ([000]) [000]-[0000]"
         allowSuggestions={true}
-        autocompleteOnFocus={false}
         autoSkip
       />
       <Button

--- a/apps/example/src/screens/ValidationRegEx/index.tsx
+++ b/apps/example/src/screens/ValidationRegEx/index.tsx
@@ -11,6 +11,7 @@ const ValidationRegex = () => {
     >
       <TextInput
         mask="[09999999].[00]"
+        defaultValue="22.11"
         allowedKeys="0123456789,."
         validationRegex={'^(?!.*[.,].*[.,])\\d*(?:[.,]\\d{0,2})?$'}
         keyboardType="decimal-pad"

--- a/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
+++ b/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
@@ -42,7 +42,7 @@ class ReactMaskedTextChangeListener(
     count: Int,
   ) {
     val newText = allowedKeys?.run { text.filter { it in this } } ?: text
-    if (!isValidText(text.toString()) || prevText == text.toString()) {
+    if (!isValidText(text.toString())) {
       this.cursorPosition = cursorPosition
       return
     }

--- a/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
+++ b/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
@@ -19,8 +19,8 @@ class ReactMaskedTextChangeListener(
   valueListener: MaskedTextValueListener,
   var allowedKeys: String?,
   private val focusChangeListener: View.OnFocusChangeListener,
-  var validationRegex: String?,
   var autocompleteOnFocus: Boolean,
+  var validationRegex: Regex?,
 ) : MaskedTextChangedListener(
     primaryFormat = primaryFormat,
     affineFormats = affineFormats,
@@ -62,15 +62,7 @@ class ReactMaskedTextChangeListener(
     super.afterTextChanged(edit)
   }
 
-  private fun isValidText(text: String): Boolean {
-    val validationRegex = this.validationRegex
-
-    return if (validationRegex == null) {
-      true
-    } else {
-      Regex(validationRegex).matches(text)
-    }
-  }
+  private fun isValidText(text: String): Boolean = this.validationRegex?.matches(text) ?: true
 
   override fun onFocusChange(
     view: View?,
@@ -97,8 +89,8 @@ class ReactMaskedTextChangeListener(
       rightToLeft: Boolean = false,
       valueListener: MaskedTextValueListener,
       allowedKeys: String?,
-      validationRegex: String?,
       autocompleteOnFocus: Boolean = false,
+      validationRegex: Regex?,
     ): ReactMaskedTextChangeListener {
       val listener =
         ReactMaskedTextChangeListener(

--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -31,8 +31,8 @@ class AdvancedTextInputMaskDecoratorView(
   private var defaultValue: String? = null
   private var value: String? = null
   private var isInitialMount = true
-  private var validationRegex: String? = null
   private var autocompleteOnFocus = false
+  private var validationRegex: Regex? = null
 
   private val valueListener =
     MaskedTextValueListener { _, extracted, formatted, tailPlaceholder ->
@@ -83,6 +83,7 @@ class AdvancedTextInputMaskDecoratorView(
             affineFormats = affineFormats,
             affinityCalculationStrategy = affinityCalculationStrategy,
             allowedKeys = allowedKeys,
+            autocompleteOnFocus = autocompleteOnFocus,
             validationRegex = validationRegex,
           )
 
@@ -150,7 +151,7 @@ class AdvancedTextInputMaskDecoratorView(
   fun setValue(value: String?) {
     this.value = value
     if (textField?.text.toString() != value) {
-      value?.let { maskedTextChangeListener?.setText(it) }
+      value?.let { maskedTextChangeListener?.setText(it, false) }
     }
   }
 
@@ -168,8 +169,12 @@ class AdvancedTextInputMaskDecoratorView(
   }
 
   fun setValidationRegex(validationRegex: String?) {
-    this.validationRegex = validationRegex
-    maskedTextChangeListener?.validationRegex = validationRegex
+    val regex =
+      validationRegex?.let {
+        Regex(it)
+      }
+    this.validationRegex = regex
+    maskedTextChangeListener?.validationRegex = regex
   }
 
   fun setAllowedKeys(allowedKeys: String?) {

--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -114,7 +114,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   @objc private var validationRegex: NSString? {
     didSet {
-      maskInputListener?.validationRegex = validationRegex as? String
+      maskInputListener?.validationRegex = getRegExFromString(string: validationRegex as String?)
     }
   }
 
@@ -143,6 +143,12 @@ class AdvancedTextInputMaskDecoratorView: UIView {
   }
 
   // MARK: - Utility Methods
+
+  private func getRegExFromString(string: String?) -> NSRegularExpression? {
+    guard let pattern = string else { return nil }
+
+    return try? NSRegularExpression(pattern: pattern)
+  }
 
   @objc private func updateTextWithoutNotification(text: String) {
     if text == textField?.attributedText?.string {
@@ -216,7 +222,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
       },
       allowSuggestions: allowSuggestions,
       allowedKeys: (allowedKeys ?? "") as String,
-      validationRegex: validationRegex as? String
+      validationRegex: getRegExFromString(string: validationRegex as String?)
     )
     maskInputListener?.textFieldDelegate = textFieldDelegate
     textField.delegate = maskInputListener

--- a/package/ios/NotifyingAdvancedTexInputMaskListener.swift
+++ b/package/ios/NotifyingAdvancedTexInputMaskListener.swift
@@ -11,7 +11,7 @@ import UIKit
 
 class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
   public var allowedKeys = ""
-  public var validationRegex: String?
+  public var validationRegex: NSRegularExpression?
 
   public init(primaryFormat: String = "",
               autocomplete: Bool = true,
@@ -28,7 +28,7 @@ class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
                  _ tailPlaceholder: String) -> Void)? = nil,
               allowSuggestions: Bool = true,
               allowedKeys: String = "",
-              validationRegex: String?)
+              validationRegex: NSRegularExpression?)
   {
     self.allowedKeys = allowedKeys
     self.validationRegex = validationRegex
@@ -51,10 +51,9 @@ class NotifyingAdvancedTexInputMaskListener: MaskedTextInputListener {
       return true
     }
 
-    let regex = try? NSRegularExpression(pattern: validationRegex)
-
     let range = NSRange(location: 0, length: text.utf16.count)
-    return regex?.firstMatch(in: text, options: [], range: range) != nil
+
+    return validationRegex.firstMatch(in: text, options: [], range: range) != nil
   }
 
   override func textField(

--- a/package/src/web/AdvancedTextInputMaskListener.ts
+++ b/package/src/web/AdvancedTextInputMaskListener.ts
@@ -26,8 +26,8 @@ class MaskedTextChangedListener {
   public rightToLeft: boolean;
   public textField: Field | null = null;
   public allowedKeys: string;
-  public validationRegex?: string;
   public autocompleteOnFocus?: boolean;
+  private validationRegex?: RegExp;
 
   private afterText: string = '';
 
@@ -51,8 +51,8 @@ class MaskedTextChangedListener {
     this.autoskip = autoskip;
     this.rightToLeft = rightToLeft;
     this.allowedKeys = allowedKeys;
-    this.validationRegex = validationRegex;
     this.autocompleteOnFocus = autocompleteOnFocus;
+    this.setValidationRegex(validationRegex);
   }
 
   public get primaryMask(): Mask {
@@ -190,7 +190,7 @@ class MaskedTextChangedListener {
   };
 
   private isValidText = (text: string): boolean =>
-    this.validationRegex ? new RegExp(this.validationRegex).test(text) : true;
+    this.validationRegex ? this.validationRegex.test(text) : true;
 
   handleFocus = (
     event: NativeSyntheticEvent<TextInputFocusEventData>
@@ -252,6 +252,18 @@ class MaskedTextChangedListener {
     }
 
     return masksAndAffinities[0]!.mask;
+  };
+
+  public setValidationRegex = (validationRegex?: string) => {
+    if (validationRegex) {
+      this.validationRegex = new RegExp(validationRegex);
+    } else {
+      this.validationRegex = undefined;
+    }
+  };
+
+  public getValidationRegex = (): string | undefined => {
+    return this.validationRegex?.source;
   };
 
   private maskGetOrCreate = (

--- a/package/src/web/hooks/useMaskedTextInputListener/index.ts
+++ b/package/src/web/hooks/useMaskedTextInputListener/index.ts
@@ -91,8 +91,8 @@ const useMaskedTextInputListener = ({
       listener.rightToLeft = isRTL;
     }
 
-    if (listener.validationRegex !== validationRegex) {
-      listener.validationRegex = validationRegex;
+    if (listener.getValidationRegex() !== validationRegex) {
+      listener.setValidationRegex(validationRegex);
     }
 
     if (listener.autocompleteOnFocus !== autocompleteOnFocus) {


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->
In this PR, I've added logic to not re-create the regular expression every time the user types, so that should improve performance a bit


## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

better performance

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro

Pixel 6a emulator

Chrome browser

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### Android

https://github.com/user-attachments/assets/de6007f5-3b24-4e81-a181-f65c237e008d

### iOS

https://github.com/user-attachments/assets/4782b012-c1cb-4549-a45f-09f8c9b53a48

### Web

https://github.com/user-attachments/assets/fb94e5ae-cfb0-4e63-98f9-5385e2bbc299

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed