### PR TITLE
fix: field becomes empty after entering forbidden character

### DIFF
--- a/package/src/web/AdvancedTextInputMaskListener.ts
+++ b/package/src/web/AdvancedTextInputMaskListener.ts
@@ -27,6 +27,7 @@ class MaskedTextChangedListener {
   public textField: Field | null = null;
   public allowedKeys: string;
   public autocompleteOnFocus?: boolean;
+  public defaultValue?: string;
   private validationRegex?: RegExp;
 
   private afterText: string = '';
@@ -41,7 +42,8 @@ class MaskedTextChangedListener {
     rightToLeft: boolean = false,
     allowedKeys: string = '',
     validationRegex?: string,
-    autocompleteOnFocus: boolean = false
+    autocompleteOnFocus: boolean = false,
+    defaultValue?: string
   ) {
     this.primaryFormat = primaryFormat;
     this.affineFormats = affineFormats;
@@ -53,6 +55,7 @@ class MaskedTextChangedListener {
     this.allowedKeys = allowedKeys;
     this.autocompleteOnFocus = autocompleteOnFocus;
     this.setValidationRegex(validationRegex);
+    this.setDefaultText(defaultValue);
   }
 
   public get primaryMask(): Mask {
@@ -191,6 +194,20 @@ class MaskedTextChangedListener {
 
   private isValidText = (text: string): boolean =>
     this.validationRegex ? this.validationRegex.test(text) : true;
+
+  private setDefaultText = (defaultValue?: string): void => {
+    this.defaultValue = defaultValue;
+    if (defaultValue) {
+      const textAndCaret = new CaretString(defaultValue, defaultValue.length, {
+        type: CaretGravityType.Forward,
+        autocomplete: false,
+        autoskip: false,
+      });
+      const result: MaskResult =
+        this.pickMask(textAndCaret).apply(textAndCaret);
+      this.afterText = result.formattedText.string;
+    }
+  };
 
   handleFocus = (
     event: NativeSyntheticEvent<TextInputFocusEventData>

--- a/package/src/web/hooks/useMaskedTextInputListener/index.ts
+++ b/package/src/web/hooks/useMaskedTextInputListener/index.ts
@@ -45,7 +45,8 @@ const useMaskedTextInputListener = ({
         isRTL,
         allowedKeys,
         validationRegex,
-        autocompleteOnFocus
+        autocompleteOnFocus,
+        defaultValue
       )
   );
 
@@ -98,6 +99,10 @@ const useMaskedTextInputListener = ({
     if (listener.autocompleteOnFocus !== autocompleteOnFocus) {
       listener.autocompleteOnFocus = autocompleteOnFocus;
     }
+
+    if (defaultValue !== listener.defaultValue) {
+      listener.setText(defaultValue ?? '', false);
+    }
   }, [
     autocompleteOnFocus,
     validationRegex,
@@ -110,6 +115,7 @@ const useMaskedTextInputListener = ({
     affinityCalculationStrategy,
     allowedKeys,
     listener,
+    defaultValue,
   ]);
 
   const handleOnChange = useCallback(


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

When you have a default value and you try to enter some forbidden character with validationRegex prop, the field becomes empty. This is because the afterText value is empty, and it reverts to that value if the validation regex is not passed. So, I added a proper logic to handle this case and it fixed the problem.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

text input should not become empty if you enter any forbidden characters.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- handling of default value in MaskedTextChangedListener class

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested on the Web browser

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### Before

https://github.com/user-attachments/assets/8fd9cdd6-e698-4925-b04f-a10aa968aa4a


### After

https://github.com/user-attachments/assets/53e5049b-4a25-4fcc-ad0c-9bd22bd33116


## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed