### PR TITLE
fix: configure text field when view moved to window

### DIFF
--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -239,9 +239,9 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   // MARK: - View Lifecycle
 
-  override func willMove(toWindow newWindow: UIWindow?) {
-    super.willMove(toWindow: newWindow)
-    if textField == nil, newWindow != nil {
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if textField == nil {
       configureTextField()
       configureMaskInputListener()
       updateTextWithoutNotification(text: value as? String ?? defaultValue as String)

--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -150,8 +150,18 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     return try? NSRegularExpression(pattern: pattern)
   }
 
+  private func setText(textField: UITextField, text: NSAttributedString) {
+    #if ADVANCE_INPUT_MASK_NEW_ARCH_ENABLED
+      textField.attributedText = text
+    #else
+      textField.allText = text.string
+    #endif
+  }
+
   @objc private func updateTextWithoutNotification(text: String) {
-    if text == textField?.attributedText?.string {
+    guard let textField = textField else { return }
+
+    if text == textField.attributedText?.string {
       return
     }
 
@@ -165,14 +175,14 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
     let attributedText = NSAttributedString(string: result.formattedText.string)
 
-    textField?.attributedText = attributedText
+    setText(textField: textField, text: attributedText)
   }
 
   @objc private func maybeUpdateText(text: String) {
     guard let primaryMask = maskInputListener?.primaryMask else { return }
     guard let textField = textField else { return }
 
-    if text == textField.allText {
+    if text == textField.attributedText?.string {
       return
     }
 
@@ -187,7 +197,9 @@ class AdvancedTextInputMaskDecoratorView: UIView {
       return
     }
 
-    textField.allText = result.formattedText.string
+    let attributedText = NSAttributedString(string: result.formattedText.string)
+
+    setText(textField: textField, text: attributedText)
     maskInputListener?.notifyOnMaskedTextChangedListeners(forTextInput: textField, result: result)
   }
 


### PR DESCRIPTION
## 📜 Description
<!-- Describe your changes in detail -->

The problem was in the willMoveToWindow function. This method is called too early, and the superview might be nil. I moved all the logic from willMoveToWindow to didMoveToWindow, which fixed the problem.

fixes #77 

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Masked text input should be configured correctly

### iOS

- replaced willMoveToWindow with didMoveToWindow

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro simulator

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

#### before:

https://github.com/user-attachments/assets/57290c16-8b0d-4166-a451-359554e07404

#### old arch:

https://github.com/user-attachments/assets/492343cb-4278-49af-bd1c-537f71378fab

#### new arch:

https://github.com/user-attachments/assets/f6bd5ae8-950e-47aa-8d3b-e34385d3c3c7

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
