### PR TITLE
fix: don't overwrite the same values for masked listener on android

### DIFF
--- a/apps/example/src/screens/ControlledInput/index.tsx
+++ b/apps/example/src/screens/ControlledInput/index.tsx
@@ -10,7 +10,11 @@ const ControlledInput = () => {
       style={styles.container}
       contentContainerStyle={styles.contentContainer}
     >
-      <TextInput controlled mask="+1 ([000]) [000]-[0000]" />
+      <TextInput
+        controlled
+        keyboardType="phone-pad"
+        mask="+1 ([000]) [000]-[0000]"
+      />
     </ScrollView>
   );
 };

--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -103,47 +103,56 @@ class AdvancedTextInputMaskDecoratorView(
   }
 
   fun setMask(format: String) {
+    if (maskFormat == format) return
     maskFormat = format
     maskedTextChangeListener?.primaryFormat = format
     maybeUpdateText()
   }
 
   fun setAffinityFormat(affinityFormat: List<String>) {
+    if (affineFormats == affinityFormat) return
     affineFormats = affinityFormat
     maskedTextChangeListener?.affineFormats = affinityFormat
   }
 
   fun setAffinityCalculationStrategy(strategy: AffinityCalculationStrategy) {
+    if (affinityCalculationStrategy == strategy) return
     affinityCalculationStrategy = strategy
     maskedTextChangeListener?.affinityCalculationStrategy = strategy
   }
 
   fun setCustomNotations(notations: List<Notation>) {
+    if (customNotations == notations) return
     customNotations = notations
     maskedTextChangeListener?.customNotations = notations
   }
 
   fun setAutoSkip(value: Boolean) {
+    if (autoSkip == value) return
     autoSkip = value
     maskedTextChangeListener?.autoskip = value
   }
 
   fun setAutoComplete(value: Boolean) {
+    if (autocomplete == value) return
     autocomplete = value
     maskedTextChangeListener?.autocomplete = value
   }
 
   fun setAutocompleteOnFocus(value: Boolean) {
+    if (autocompleteOnFocus == value) return
     autocompleteOnFocus = value
     maskedTextChangeListener?.autocompleteOnFocus = value
   }
 
   fun setIsRtl(rtl: Boolean) {
+    if (isRtl == rtl) return
     isRtl = rtl
     maskedTextChangeListener?.rightToLeft = rtl
   }
 
   fun setDefaultValue(defaultValue: String?) {
+    if (this.defaultValue == defaultValue) return
     this.defaultValue = defaultValue
     applyDefaultValue()
   }
@@ -169,6 +178,7 @@ class AdvancedTextInputMaskDecoratorView(
   }
 
   fun setValidationRegex(validationRegex: String?) {
+    if (this.validationRegex.toString() == validationRegex) return
     val regex =
       validationRegex?.let {
         Regex(it)
@@ -178,6 +188,7 @@ class AdvancedTextInputMaskDecoratorView(
   }
 
   fun setAllowedKeys(allowedKeys: String?) {
+    if (this.allowedKeys == allowedKeys) return
     this.allowedKeys = allowedKeys
     maskedTextChangeListener?.allowedKeys = allowedKeys
     maybeUpdateText()


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

The problem was that we were overwriting the parameters on each component rerender in the native part of the code and because of this a race condition occurred when the user typed fast. So I added checks to not overwrite the values if they are the same.

fixes #82 

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Don't set the same values

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added checks for current and next values in AdvancedTextInputMaskDecoratorView
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

Pixel 6a emulator

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### before

Uploading Screen Recording 2025-02-27 at 12.02.02.mov…


### after

https://github.com/user-attachments/assets/4b638016-acfb-41c4-a47d-d2e5ab2f0fdd



## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
