### PR TITLE
fix: revert autocomplete is false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,27 +130,27 @@ For applications requiring conditional or more complex formatting, this package 
 
 ### MaskedTextInput Component - Props
 
-| Prop                          | Type                                             | Description                                                                                                                             |
-| ----------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `mask`                        | `string`                                         | The mask format to be applied to the text input, defining the pattern for formatting. Example: `"[0000] [0000] [0000] [0000]"`.         |
-| `customNotations`             | `Notation[]`                                     | Array of custom notations for the mask format. Each notation object includes: `character`, `characterSet`, and `isOptional`.            |
-| `allowedKeys`                 | `string`                                         | A string specifying the characters that are permitted for input.                                                                        |
-| `validationRegex`             | `regex string`                                   | A validation regex that runs before applying the mask.                                                                                  |
-| `onChangeText`                | `(formatted: string, extracted: string) => void` | Callback function triggered on text change. Receives `formattedValue` (with mask) and `extractedValue` (raw input).                     |
-| `onTailPlaceholderChange`     | `(tailPlaceholder: string) => void`              | Callback function called when the tail placeholder changes, receiving the updated `tailPlaceholder` value.                              |
-| `affinityFormat`              | `string[]`                                       | Array of strings for affinity format, used to determine the best mask format based on the input.                                        |
-| `autocomplete`                | `boolean`                                        | Enables or disables autocomplete for the text input. Default is `false`.(NOTE: this prop might work wrong with controlled text inputs). |
-| `autoSkip`                    | `boolean`                                        | Automatically skips to the next input field when the current one is filled. Default is `false`.                                         |
-| `isRTL`                       | `boolean`                                        | Enables right-to-left (RTL) text direction for the text input. Default is `false`.                                                      |
-| `affinityCalculationStrategy` | `AFFINITY_CALCULATION_STRATEGY`                  | Defines the strategy for affinity calculation, determining how the best mask format is selected based on input.                         |
-| `customTransformation`        | `CustomTransformation`                           | Custom transformation applied to the text input to define how the input text should be transformed.                                     |
-| `defaultValue`                | `string`                                         | The default value for the input field.                                                                                                  |
-| `value`                       | `string`                                         | Current value of the input field, allowing controlled input behavior.                                                                   |
-| `allowSuggestions`            | `boolean` (iOS only)                             | Enables or disables input suggestions on iOS. Default is `false`.                                                                       |
-| `autocompleteOnFocus`         | `boolean`                                        | Enables autocomplete when the text input is focused.                                                                                    |
-| `placeholder`                 | `string`                                         | Placeholder text displayed in the input.                                                                                                |
-| `keyboardType`                | `string`                                         | Sets the keyboard type. Useful for numeric masks with `keyboardType="numeric"`.                                                         |
-| `autoFocus`                   | `boolean`                                        | If `true`, focuses the input on component load. Default is `false`.                                                                     |
+| Prop                          | Type                                             | Description                                                                                                                     |
+| ----------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `mask`                        | `string`                                         | The mask format to be applied to the text input, defining the pattern for formatting. Example: `"[0000] [0000] [0000] [0000]"`. |
+| `customNotations`             | `Notation[]`                                     | Array of custom notations for the mask format. Each notation object includes: `character`, `characterSet`, and `isOptional`.    |
+| `allowedKeys`                 | `string`                                         | A string specifying the characters that are permitted for input.                                                                |
+| `validationRegex`             | `regex string`                                   | A validation regex that runs before applying the mask.                                                                          |
+| `onChangeText`                | `(formatted: string, extracted: string) => void` | Callback function triggered on text change. Receives `formattedValue` (with mask) and `extractedValue` (raw input).             |
+| `onTailPlaceholderChange`     | `(tailPlaceholder: string) => void`              | Callback function called when the tail placeholder changes, receiving the updated `tailPlaceholder` value.                      |
+| `affinityFormat`              | `string[]`                                       | Array of strings for affinity format, used to determine the best mask format based on the input.                                |
+| `autocomplete`                | `boolean`                                        | Enables or disables autocomplete for the text input. Default is `true`                                                          |
+| `autoSkip`                    | `boolean`                                        | Automatically skips to the next input field when the current one is filled. Default is `false`.                                 |
+| `isRTL`                       | `boolean`                                        | Enables right-to-left (RTL) text direction for the text input. Default is `false`.                                              |
+| `affinityCalculationStrategy` | `AFFINITY_CALCULATION_STRATEGY`                  | Defines the strategy for affinity calculation, determining how the best mask format is selected based on input.                 |
+| `customTransformation`        | `CustomTransformation`                           | Custom transformation applied to the text input to define how the input text should be transformed.                             |
+| `defaultValue`                | `string`                                         | The default value for the input field.                                                                                          |
+| `value`                       | `string`                                         | Current value of the input field, allowing controlled input behavior.                                                           |
+| `allowSuggestions`            | `boolean` (iOS only)                             | Enables or disables input suggestions on iOS. Default is `false`.                                                               |
+| `autocompleteOnFocus`         | `boolean`                                        | Enables autocomplete when the text input is focused.                                                                            |
+| `placeholder`                 | `string`                                         | Placeholder text displayed in the input.                                                                                        |
+| `keyboardType`                | `string`                                         | Sets the keyboard type. Useful for numeric masks with `keyboardType="numeric"`.                                                 |
+| `autoFocus`                   | `boolean`                                        | If `true`, focuses the input on component load. Default is `false`.                                                             |
 
 ## Cookbook
 

--- a/apps/example/src/components/TextInput/index.tsx
+++ b/apps/example/src/components/TextInput/index.tsx
@@ -22,7 +22,6 @@ const TextInput: FC<Props> = (props) => {
     onBlur,
     style,
     defaultValue,
-    autocomplete,
     ...rest
   } = props;
 
@@ -78,7 +77,6 @@ const TextInput: FC<Props> = (props) => {
       <MaskedTextInput
         ref={inputRef}
         {...rest}
-        autocomplete={autocomplete ?? !controlled}
         defaultValue={defaultValue}
         renderTextInputComponent={BaseTextInput}
         style={style}

--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -23,7 +23,7 @@ class AdvancedTextInputMaskDecoratorView(
   private var affineFormats = emptyList<String>()
   private var customNotations = emptyList<Notation>()
   private var autoSkip = false
-  private var autocomplete = false
+  private var autocomplete = true
   private var isRtl = false
   private var customTransformationMethod: CustomTransformationMethod? = null
   private var maskedTextChangeListener: ReactMaskedTextChangeListener? = null

--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -34,7 +34,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     }
   }
 
-  @objc private var autocomplete: Bool = false {
+  @objc private var autocomplete: Bool = true {
     didSet {
       maskInputListener?.autocomplete = autocomplete
     }

--- a/package/src/web/AdvancedTextInputMaskListener.ts
+++ b/package/src/web/AdvancedTextInputMaskListener.ts
@@ -37,7 +37,7 @@ class MaskedTextChangedListener {
     affineFormats: string[] = [],
     customNotations: Notation[] = [],
     affinityCalculationStrategy: AFFINITY_CALCULATION_STRATEGY = AFFINITY_CALCULATION_STRATEGY.WHOLE_STRING,
-    autocomplete: boolean = false,
+    autocomplete: boolean = true,
     autoskip: boolean = false,
     rightToLeft: boolean = false,
     allowedKeys: string = "",


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

I want to set autocomplete as true by default as it was before to avoid breaking changes for people who use my library.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Don't bring breaking changes

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro

Pixel 6a emulator

Chrome

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->


https://github.com/user-attachments/assets/f2a38757-99f9-4700-842f-4ddb1de69ec0


https://github.com/user-attachments/assets/aae2d47b-adca-4506-ba53-49c2dbe6c6e0


https://github.com/user-attachments/assets/bc81c4b5-47fe-4e41-a868-dfbca38f64ca



## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
