### PR TITLE
fix: android initial value with autocomplete=true

### DIFF
--- a/apps/example/src/screens/ControlledInput/index.tsx
+++ b/apps/example/src/screens/ControlledInput/index.tsx
@@ -12,6 +12,7 @@ const ControlledInput = () => {
     >
       <TextInput
         controlled
+        initialValue="1111"
         keyboardType="phone-pad"
         mask="+1 ([000]) [000]-[0000]"
       />

--- a/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
+++ b/package/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
@@ -41,6 +41,8 @@ class ReactMaskedTextChangeListener(
     before: Int,
     count: Int,
   ) {
+    if (prevText == field.text.toString()) return
+
     val newText = allowedKeys?.run { text.filter { it in this } } ?: text
     if (!isValidText(text.toString())) {
       this.cursorPosition = cursorPosition
@@ -51,6 +53,8 @@ class ReactMaskedTextChangeListener(
   }
 
   override fun afterTextChanged(edit: Editable?) {
+    if (prevText == field.text.toString()) return
+
     val stringText = edit.toString()
     if (!isValidText(stringText)) {
       field.setText(prevText)

--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -78,7 +78,7 @@ class AdvancedTextInputMaskDecoratorView(
             primaryFormat = maskFormat,
             valueListener = valueListener,
             autoSkip = autoSkip,
-            autocomplete = autocomplete,
+            autocomplete = false,
             rightToLeft = isRtl,
             affineFormats = affineFormats,
             affinityCalculationStrategy = affinityCalculationStrategy,
@@ -89,6 +89,7 @@ class AdvancedTextInputMaskDecoratorView(
 
         if (isInitialMount) {
           applyDefaultValue()
+          maskedTextChangeListener?.autocomplete = autocomplete
           isInitialMount = false
         }
       }


### PR DESCRIPTION
## 📜 Description

I don't know why, but react-native sets the text multiple times. To avoid applying the mask multiple times, I added logic to compare the previously entered value with the next value and added setting the initial value after applying the initial value

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Do not apply the mask if the text has not been modified


## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Pixel 6a emulator

## 📸 Screenshots (if appropriate):

### Old arch:

https://github.com/user-attachments/assets/516b07d4-872c-41ee-8049-f66b4cde0b5a

### New arch:

https://github.com/user-attachments/assets/c4c6c684-1c09-46af-8077-760852d9918b


<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
