### PR TITLE
feat: move fabric detection to a separate file

### DIFF
--- a/package/src/native/architecture.ts
+++ b/package/src/native/architecture.ts
@@ -1,0 +1,1 @@
+export const IS_FABRIC = "nativeFabricUIManager" in global;

--- a/package/src/native/views/MaskedTextInput/index.tsx
+++ b/package/src/native/views/MaskedTextInput/index.tsx
@@ -2,6 +2,7 @@ import { StyleSheet, TextInput } from "react-native";
 import React, { forwardRef, memo, useCallback } from "react";
 import MaskedTextInputDecoratorView from "../../MaskedTextInputNative";
 import type { MaskedTextInputProps } from "../../../types";
+import { IS_FABRIC } from "../../architecture";
 
 const styles = StyleSheet.create({
   displayNone: {
@@ -39,7 +40,6 @@ const MaskedTextInput = forwardRef<TextInput, MaskedTextInputProps>(
     ref,
   ) => {
     const InputComponent = renderTextInputComponent ?? TextInput;
-    const IS_FABRIC = "nativeFabricUIManager" in global;
 
     const onAdvancedMaskTextChangeCallback = useCallback(
       ({ nativeEvent: { extracted, formatted, tailPlaceholder } }) => {


### PR DESCRIPTION
## 📜 Description

I want to keep my codebase clean, and there is no need to constantly check that ‘nativeFabricUIManager’ is declared in global. So, I moved fabric detection to a separate file.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- moved architecture detection to a separate file


## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

Pixel 6a emulator

iPhone 15 pro

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
