### PR TITLE
fix: properly set initial value on iOS

### DIFF
--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -203,6 +203,11 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     maskInputListener?.notifyOnMaskedTextChangedListeners(forTextInput: textField, result: result)
   }
 
+  private func getInitialText() -> String {
+    let value = (value as? String) ?? ""
+    return value.isEmpty ? (defaultValue as String) : value
+  }
+
   // MARK: - Configuration Methods
 
   private func configureTextField() {
@@ -256,7 +261,8 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     if textField == nil {
       configureTextField()
       configureMaskInputListener()
-      updateTextWithoutNotification(text: value as? String ?? defaultValue as String)
+      let initialText = getInitialText()
+      updateTextWithoutNotification(text: initialText)
     }
   }
 }

--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -169,7 +169,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     let caretString = CaretString(
       string: text,
       caretPosition: text.endIndex,
-      caretGravity: CaretString.CaretGravity.forward(autocomplete: autocomplete)
+      caretGravity: CaretString.CaretGravity.forward(autocomplete: false)
     )
     let result = primaryMask.apply(toText: caretString)
 
@@ -189,7 +189,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
     let caretString = CaretString(
       string: text,
       caretPosition: text.endIndex,
-      caretGravity: CaretString.CaretGravity.forward(autocomplete: autocomplete)
+      caretGravity: CaretString.CaretGravity.forward(autocomplete: false)
     )
     let result = primaryMask.apply(toText: caretString)
 


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

The problem is that for unknown reason we get value for uncontrolled text inputs as empty String, however the initial value is nil. It happens when you enter the controlled text input example.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->


### iOS

- getInitialText util


## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 15 pro


## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### New arch:

https://github.com/user-attachments/assets/f1622f36-e767-4511-b85b-29281c363c78

### Old arch:

https://github.com/user-attachments/assets/14a8294f-741c-44bb-946d-408c055dbe5e



## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
