### PR TITLE
fix: add affineFormat for iOS old arch

### DIFF
--- a/package/ios/MaskedTextInputManager.mm
+++ b/package/ios/MaskedTextInputManager.mm
@@ -14,6 +14,7 @@ RCT_EXPORT_VIEW_PROPERTY(allowSuggestions, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(defaultValue, NSString)
 RCT_EXPORT_VIEW_PROPERTY(value, NSString)
 RCT_EXPORT_VIEW_PROPERTY(validationRegex, NSString)
+RCT_EXPORT_VIEW_PROPERTY(affinityFormat, NSArray)
 
 RCT_EXPORT_VIEW_PROPERTY(onAdvancedMaskTextChange, RCTDirectEventBlock);
 @end


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

I forgot to add this prop for the old arch for iOS. So, I aded it and it fixed crash.

fixes: #97 

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We should support all props for all archs

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added RCT_EXPORT_VIEW_PROPERTY(affinityFormat, NSArray)

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested on iPhon 15pro iOS 17.5

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

https://github.com/user-attachments/assets/225d4610-74e8-4ec0-8a3c-9b56f4162bdc


## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
