### PR TITLE
fix: return MapBuilder

### DIFF
--- a/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
+++ b/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
@@ -3,6 +3,8 @@ package com.maskedtextinput.managers
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.common.MapBuilder
+import com.facebook.react.common.MapBuilder.newHashMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.maskedtextinput.AdvancedTextInputMaskDecoratorViewManagerSpec
@@ -128,9 +130,9 @@ class AdvancedTextInputMaskDecoratorViewManager(
   }
 
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
-    val export = super.getExportedCustomDirectEventTypeConstants() ?: hashMapOf()
+    val export = super.getExportedCustomDirectEventTypeConstants() ?: newHashMap()
 
-    export[EventNames.CHANGE_TEXT_EVENT] = mapOf("registrationName" to "onAdvancedMaskTextChange")
+    export[EventNames.CHANGE_TEXT_EVENT] = MapBuilder.of("registrationName", "onAdvancedMaskTextChange")
 
     return export
   }


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

In terms to support older versions of react-native we need to use MapBuilder. So, I returned it in the codebase.

fixes #100 

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Support for older versions is also important!

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- MapBuilder instead of mapOf
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Android emulator

## 📸 Screenshots (if appropriate):

old arch:


https://github.com/user-attachments/assets/e1706ff8-dcb8-447b-b929-44234770a6ce

new arch:


https://github.com/user-attachments/assets/c5976e21-ff12-4b4a-8150-bb5cd5996efd



<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
