### PR TITLE
feat: add setText native command

### DIFF
--- a/apps/example/src/components/TextInput/index.tsx
+++ b/apps/example/src/components/TextInput/index.tsx
@@ -14,7 +14,7 @@ import Button from "../Button";
 
 import styles from "./styles";
 
-import type { TextInput as RNTextInput } from "react-native";
+import type { MaskedTextInputRef } from "package/src/types";
 
 type Props = MaskedTextInputProps & {
   controlled?: boolean;
@@ -33,7 +33,7 @@ const TextInput: FC<Props> = (props) => {
     ...rest
   } = props;
 
-  const inputRef = React.useRef<RNTextInput>(null);
+  const inputRef = React.useRef<MaskedTextInputRef>(null);
 
   const [textState, setTextState] = React.useState({
     extracted: initialValue || defaultValue,
@@ -73,6 +73,10 @@ const TextInput: FC<Props> = (props) => {
     setTextState({ extracted: "", formatted: "" });
   }, [controlled]);
 
+  const handleSetText = React.useCallback(() => {
+    inputRef.current?.setText("999999", false);
+  }, []);
+
   const handleFocusButtonPress = React.useCallback(() => {
     inputRef.current?.focus();
   }, []);
@@ -102,6 +106,11 @@ const TextInput: FC<Props> = (props) => {
         style={styles.button}
         title="Focus text input"
         onPress={handleFocusButtonPress}
+      />
+      <Button
+        style={styles.button}
+        title={"Set text"}
+        onPress={handleSetText}
       />
     </>
   );

--- a/e2e/.maestro/clear-text.yaml
+++ b/e2e/.maestro/clear-text.yaml
@@ -1,0 +1,15 @@
+appId: "com.maskedtextinputexample"
+---
+- launchApp
+- tapOn:
+    id: "phone-input"
+- tapOn: "+1 (000) 000-0000"
+- inputText: 1
+- assertVisible: "formatted value +1 ("
+- tapOn:
+    point: "50%,37%"
+- tapOn: "Clear text"
+- assertVisible: "+1 (000) 000-0000"
+- tapOn: "+1 (000) 000-0000"
+- inputText: 1
+- assertVisible: "formatted value +1 ("

--- a/e2e/.maestro/set-text.yaml
+++ b/e2e/.maestro/set-text.yaml
@@ -1,0 +1,9 @@
+appId: "com.maskedtextinputexample"
+---
+- launchApp
+- tapOn:
+    id: "phone-input"
+- tapOn: "+1 (000) 000-0000"
+- tapOn: "Set text"
+- assertVisible: "+1 (999) 999"
+- assertVisible: "formatted value +1 (999) 999"

--- a/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
+++ b/package/android/src/main/java/com/maskedtextinput/managers/AdvancedTextInputMaskDecoratorViewManager.kt
@@ -18,6 +18,16 @@ class AdvancedTextInputMaskDecoratorViewManager(
 ) : AdvancedTextInputMaskDecoratorViewManagerSpec<AdvancedTextInputMaskDecoratorView>() {
   override fun getName() = NAME
 
+  override fun setText(
+    view: AdvancedTextInputMaskDecoratorView,
+    text: String?,
+    autocomplete: Boolean,
+  ) {
+    if (text != null) {
+      view.setText(text, autocomplete)
+    }
+  }
+
   override fun createViewInstance(context: ThemedReactContext) = AdvancedTextInputMaskDecoratorView(context)
 
   @ReactProp(name = "primaryMaskFormat")

--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -194,4 +194,16 @@ class AdvancedTextInputMaskDecoratorView(
     maskedTextChangeListener?.allowedKeys = allowedKeys
     maybeUpdateText()
   }
+
+  fun setText(
+    text: String,
+    autocomplete: Boolean = false,
+  ) {
+    maskedTextChangeListener?.let {
+      val prevAutocomplete = it.autocomplete
+      it.autocomplete = autocomplete
+      it.setText(text, autocomplete)
+      it.autocomplete = prevAutocomplete
+    }
+  }
 }

--- a/package/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
+++ b/package/android/src/oldarch/java/com/maskedtextinput/AdvancedTextInputMaskDecoratorViewManagerSpec.kt
@@ -75,4 +75,31 @@ abstract class AdvancedTextInputMaskDecoratorViewManagerSpec<T : View> : SimpleV
     view: T,
     validationRegex: String?,
   )
+
+  abstract fun setText(
+    view: T,
+    text: String?,
+    autocomplete: Boolean,
+  )
+
+  override fun receiveCommand(
+    root: T,
+    commandId: String?,
+    args: ReadableArray?,
+  ) {
+    super.receiveCommand(root, commandId, args)
+    when (commandId) {
+      SET_TEXT -> {
+        val text = args?.getString(0)
+        val autocomplete = args?.getBoolean(1)
+        if (text != null && autocomplete != null) {
+          this.setText(root, text, autocomplete)
+        }
+      }
+    }
+  }
+
+  companion object {
+    const val SET_TEXT = "setText"
+  }
 }

--- a/package/ios/AdvancedTextInputMaskDecoratorViewManager.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorViewManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 @objc(AdvancedTextInputMaskDecoratorViewManager)
 class AdvancedTextInputMaskDecoratorViewManager: RCTViewManager {
@@ -14,6 +15,20 @@ class AdvancedTextInputMaskDecoratorViewManager: RCTViewManager {
   }
 
   override public static func requiresMainQueueSetup() -> Bool {
-    false
+    true
+  }
+
+  @objc(setText:text:autocomplete:)
+  public func setText(_ reactTag: NSNumber, text: NSString, autocomplete: Bool) {
+    bridge.uiManager.addUIBlock { _, viewRegistry in
+      guard let view = viewRegistry?[reactTag] as? AdvancedTextInputMaskDecoratorView else {
+        if RCT_DEBUG == 1 {
+          print("Invalid view returned from registry, expecting ContainerView")
+        }
+        return
+      }
+
+      view.setMaskedText(text: text, autocomplete: autocomplete)
+    }
   }
 }

--- a/package/ios/AdvancedTextInputViewContainer.h
+++ b/package/ios/AdvancedTextInputViewContainer.h
@@ -32,4 +32,5 @@
 - (void)setAffinityCalculationStrategy:(NSInteger)affinityCalculationStrategy;
 - (void)setValidationRegex:(NSString *)validationRegex;
 - (void)cleanup;
+- (void)setMaskedText:(NSString *_Nonnull)text autocomplete:(BOOL)autocomplete;
 @end

--- a/package/ios/AdvancedtextInputMaskDecoratorView.mm
+++ b/package/ios/AdvancedtextInputMaskDecoratorView.mm
@@ -150,6 +150,16 @@ using namespace facebook::react;
       ->onAdvancedMaskTextChange(event);
 }
 
+- (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args
+{
+  RCTAdvancedTextInputMaskDecoratorViewHandleCommand(self, commandName, args);
+}
+
+- (void)setText:(NSString *)text autocomplete:(BOOL)autocomplete
+{
+  [_view setMaskedText:text autocomplete:autocomplete];
+}
+
 @end
 
 Class<RCTComponentViewProtocol> AdvancedTextInputMaskDecoratorViewCls(void)

--- a/package/ios/MaskedTextInput-Bridging-Header.h
+++ b/package/ios/MaskedTextInput-Bridging-Header.h
@@ -1,6 +1,8 @@
 #import <React/RCTBackedTextInputDelegateAdapter.h>
 #import <React/RCTBaseTextInputView.h>
+#import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTUIManager.h>
 #import <React/RCTUITextField.h>
 #import <React/RCTUITextView.h>
 #import <React/RCTViewManager.h>

--- a/package/ios/MaskedTextInputManager.mm
+++ b/package/ios/MaskedTextInputManager.mm
@@ -17,4 +17,10 @@ RCT_EXPORT_VIEW_PROPERTY(validationRegex, NSString)
 RCT_EXPORT_VIEW_PROPERTY(affinityFormat, NSArray)
 
 RCT_EXPORT_VIEW_PROPERTY(onAdvancedMaskTextChange, RCTDirectEventBlock);
+
+RCT_EXTERN_METHOD(setText
+                  : (nonnull NSNumber *)reactTag text
+                  : (nonnull NSString *)text autocomplete
+                  : (nonnull BOOL)autocomplete);
+
 @end

--- a/package/src/native/MaskedTextInputNative.tsx
+++ b/package/src/native/MaskedTextInputNative.tsx
@@ -1,7 +1,0 @@
-import type { NativeProps } from "./specs/AdvancedTextInputMaskDecoratorViewNativeComponent";
-import type { FC } from "react";
-
-const MaskedTextInputDecoratorView: FC<NativeProps> =
-  require("./specs/AdvancedTextInputMaskDecoratorViewNativeComponent").default;
-
-export default MaskedTextInputDecoratorView;

--- a/package/src/native/specs/AdvancedTextInputMaskDecoratorViewNativeComponent.ts
+++ b/package/src/native/specs/AdvancedTextInputMaskDecoratorViewNativeComponent.ts
@@ -1,3 +1,4 @@
+import codegenNativeCommands from "react-native/Libraries/Utilities/codegenNativeCommands";
 import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNativeComponent";
 
 import type { HostComponent } from "react-native";
@@ -50,6 +51,18 @@ export interface NativeProps extends ViewProps {
   value?: string;
   validationRegex?: string;
 }
+
+export interface NativeCommands {
+  setText: (
+    viewRef: React.ElementRef<HostComponent<NativeProps>>,
+    text: string,
+    autocomplete: boolean,
+  ) => void;
+}
+
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ["setText"],
+});
 
 export default codegenNativeComponent<NativeProps>(
   "AdvancedTextInputMaskDecoratorView",

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -102,5 +102,15 @@ export type MaskedTextInputOwnProps = {
   validationRegex?: string;
 };
 
+export type MaskedTextInputRef = {
+  setText: (text: string, autocomplete?: boolean) => void;
+  clear: () => void;
+  blur: () => void;
+  isFocused: () => boolean;
+  focus: () => void;
+  setNativeProps: (props: object) => void;
+  setSelection: (start: number, end: number) => void;
+};
+
 export type MaskedTextInputProps = Omit<TextInputProps, "onChangeText"> &
   MaskedTextInputOwnProps;


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

It looks like when we call `clear` method from react-native it doesn't notify text listeners about it on the native side. So, I decided to implement our own methods to control it.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

It solves a problem with the correct updating of dispatched text

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added two methods setText(text: string, autocomplete: boolean) and clear

### iOS

- added setText native command

### Android

- added setText native command

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

### new arch


https://github.com/user-attachments/assets/4e808b65-d05d-4180-852a-21da4c2408fa


https://github.com/user-attachments/assets/c8dd24f6-fc12-48cf-aa41-40c8e711e88b

### old arch


https://github.com/user-attachments/assets/427f939f-2648-4f4e-9fb0-44e036c15604


https://github.com/user-attachments/assets/f97966f5-a190-4732-9a12-655ad45353f2



## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
