### PR TITLE
fix: remove verification of a previously sent event on iOS

### DIFF
--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -23,7 +23,6 @@ class AdvancedTextInputMaskDecoratorView: UIView {
 
   private var textField: UITextField?
   private var maskInputListener: NotifyingAdvancedTexInputMaskListener?
-  private var lastDispatchedEvent: [String: String] = [:]
   private var textFieldDelegate: UITextFieldDelegate?
   private weak var originalTextFieldDelegate: UITextFieldDelegate?
 
@@ -141,14 +140,7 @@ class AdvancedTextInputMaskDecoratorView: UIView {
       "tailPlaceholder": tailPlaceholder,
     ]
 
-    if NSDictionary(dictionary: eventData).isEqual(to: lastDispatchedEvent) {
-      return
-    }
-
-    lastDispatchedEvent = eventData
-    if onAdvancedMaskTextChange != nil {
-      onAdvancedMaskTextChange!(eventData)
-    }
+    onAdvancedMaskTextChange?(eventData)
     delegate?.onAdvancedMaskTextChange(eventData: eventData as NSDictionary)
   }
 


### PR DESCRIPTION
## 📜 Description

I added this logic to be consistent with android platfrom which dispatches these event twice. However, iOS works well without this and we can remove this check.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- remove check for the previous dispatched event
-


## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 16 pro simulator

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

#### Before:

Fabric:

https://github.com/user-attachments/assets/ae805af6-feb1-45be-aa8b-3ab976e92d3a


Old:

https://github.com/user-attachments/assets/df86444b-c6bd-4313-b81d-11665799618f


#### After:

Fabric:

https://github.com/user-attachments/assets/e592cb3b-6f0a-411c-beb3-5e0e7e9c6eb6


Old:

https://github.com/user-attachments/assets/e46eac6d-9702-4083-9b0a-ca91619aecfe




## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
