### PR TITLE
feat: add MaskedTextInputRef to export

### DIFF
--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -1,9 +1,9 @@
 import { AFFINITY_CALCULATION_STRATEGY } from "./enums";
 import MaskedTextInput from "./native/views/MaskedTextInput";
 
-import type { MaskedTextInputProps } from "./types";
+import type { MaskedTextInputProps, MaskedTextInputRef } from "./types";
 
-export type { MaskedTextInputProps };
+export type { MaskedTextInputProps, MaskedTextInputRef };
 
 export { AFFINITY_CALCULATION_STRATEGY };
 


### PR DESCRIPTION
## 📜 Description

Export `MaskedTextInputRef` alongside `MaskedTextInputProps`.

## 💡 Motivation and Context

Allows proper typing when using `useRef` with `MaskedTextInput`, e.g.:
`const inputWithMaskRef = useRef<MaskedTextInputRef>(null);`

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- Exported `MaskedTextInputRef` type from the module, same as `MaskedTextInputProps`.

### iOS

-

### Android

-

## 🤔 How Has This Been Tested?

- Confirmed the type is correctly exported and usable in an external project.
- No runtime changes; type-only update.

## 📸 Screenshots (if appropriate):

<!-- Not applicable -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed (not applicable)
