### PR TITLE
fix: build on react-native 0.80

### DIFF
--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -98,7 +98,9 @@ class AdvancedTextInputMaskDecoratorView(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
-    textField?.removeTextChangedListener(maskedTextChangeListener)
+    maskedTextChangeListener?.let {
+      textField?.removeTextChangedListener(it)
+    }
     textField = null
     maskedTextChangeListener = null
   }


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

The problem was introduced by rewriting react-native core to kotlin which actually has nullability check.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I want to allow people to use my library with the latest react-native.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- Added nullability check before removing text watcher 
-

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

tested on Android emulator

## 📸 Screenshots (if appropriate):


https://github.com/user-attachments/assets/9c42524f-2804-422c-9ba9-7de6748015c5



<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
