### PR TITLE
fix: keyboard controller with autofocus

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install app on simulator
         run: |
-          UDID=$(xcrun simctl list devices | grep "iPhone 15 Pro (" | grep -oE "[0-9A-F-]{36}" | head -n 1)
+          UDID=$(xcrun simctl list devices | grep "iPhone 16 Pro (" | grep -oE "[0-9A-F-]{36}" | head -n 1)
           open -a Simulator --args -CurrentDeviceUDID $UDID
           osascript -e 'tell application "Simulator" to activate'
           xcrun simctl install "$UDID" apps/example/ios/build/Build/Products/Release-iphonesimulator/MaskedTextInputExample.app

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           UDID=$(xcrun simctl list devices | grep "iPhone 16 Pro (" | grep -oE "[0-9A-F-]{36}" | head -n 1)
           open -a Simulator --args -CurrentDeviceUDID $UDID
+          xcrun simctl bootstatus "$UDID"
           osascript -e 'tell application "Simulator" to activate'
           xcrun simctl install "$UDID" apps/example/ios/build/Build/Products/Release-iphonesimulator/MaskedTextInputExample.app
 

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2255,76 +2255,76 @@ SPEC CHECKSUMS:
   ForkInputMask: 55e3fbab504b22da98483e9f9a6514b98fdd2f3c
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
   RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e
   RCTTypeSafety: 659ae318c09de0477fd27bbc9e140071c7ea5c93
   React: c2d3aa44c49bb34e4dfd49d3ee92da5ebacc1c1c
   React-callinvoker: 1bdfb7549b5af266d85757193b5069f60659ef9d
-  React-Core: 10597593fdbae06f0089881e025a172e51d4a769
-  React-CoreModules: 6907b255529dd46895cf687daa67b24484a612c2
-  React-cxxreact: a9f5b8180d6955bc3f6a3fcd657c4d9b4d95c1f6
+  React-Core: 7150cf9b6a5af063b37003062689f1691e79c020
+  React-CoreModules: 15a85e6665d61678942da6ae485b351f4c699049
+  React-cxxreact: 74f9de59259ac951923f5726aa14f0398f167af9
   React-debug: e74e76912b91e08d580c481c34881899ccf63da9
-  React-defaultsnativemodule: 11f6ee2cf69bf3af9d0f28a6253def33d21b5266
-  React-domnativemodule: f940bbc4fa9e134190acbf3a4a9f95621b5a8f51
-  React-Fabric: 6f5c357bf3a42ff11f8844ad3fc7a1eb04f4b9de
-  React-FabricComponents: 10e0c0209822ac9e69412913a8af1ca33573379b
-  React-FabricImage: f582e764072dfa4715ae8c42979a5bace9cbcc12
+  React-defaultsnativemodule: 628285212bbd65417d40ad6a9f8781830fda6c98
+  React-domnativemodule: 185d9808198405c176784aaf33403d713bd24fb7
+  React-Fabric: c814804affbe1952e16149ddd20256e1bccae67e
+  React-FabricComponents: 81ef47d596966121784afec9924f9562a29b1691
+  React-FabricImage: f14f371d678aa557101def954ac3ba27e48948ff
   React-featureflags: d5facceff8f8f6de430e0acecf4979a9a0839ba9
-  React-featureflagsnativemodule: a7dd141f1ef4b7c1331af0035689fbc742a49ff4
-  React-graphics: 36ae3407172c1c77cea29265d2b12b90aaef6aa0
-  React-hermes: 9116d4e6d07abeb519a2852672de087f44da8f12
-  React-idlecallbacksnativemodule: ae7f5ffc6cf2d2058b007b78248e5b08172ad5c3
-  React-ImageManager: 9daee0dc99ad6a001d4b9e691fbf37107e2b7b54
-  React-jserrorhandler: 1e6211581071edaf4ecd5303147328120c73f4dc
-  React-jsi: 753ba30c902f3a41fa7f956aca8eea3317a44ee6
-  React-jsiexecutor: 47520714aa7d9589c51c0f3713dfbfca4895d4f9
-  React-jsinspector: cfd27107f6d6f1076a57d88c932401251560fe5f
-  React-jsinspectortracing: 76a7d791f3c0c09a0d2bf6f46dfb0e79a4fcc0ac
-  React-jsitooling: 995e826570dd58f802251490486ebd3244a037ab
-  React-jsitracing: 094ae3d8c123cea67b50211c945b7c0443d3e97b
-  React-logger: 8edfcedc100544791cd82692ca5a574240a16219
-  React-Mapbuffer: c3f4b608e4a59dd2f6a416ef4d47a14400194468
-  React-microtasksnativemodule: 054f34e9b82f02bd40f09cebd4083828b5b2beb6
-  react-native-advanced-input-mask: 82c5a6e8a67e9144573a9451c13859c37f3430f5
-  react-native-keyboard-controller: 56db363cb5313c7a8c29e4144c02f9b8a2fc96da
-  react-native-safe-area-context: 562163222d999b79a51577eda2ea8ad2c32b4d06
-  React-NativeModulesApple: 2c4377e139522c3d73f5df582e4f051a838ff25e
+  React-featureflagsnativemodule: 96f0ab285382d95c90f663e02526a5ceefa95a11
+  React-graphics: 1a66ee0a3f093b125b853f6370296fadcaf6f233
+  React-hermes: 8b86e5f54a65ecb69cdf22b3a00a11562eda82d2
+  React-idlecallbacksnativemodule: 5c25ab145c602264d00cb26a397ab52e0efa031c
+  React-ImageManager: 15e34bd5ef1ac4a18e96660817ef70a7f99ee8c2
+  React-jserrorhandler: 02cdf2cd45350108be1ffd2b164578936dbbdff7
+  React-jsi: 6af1987cfbb1b6621664fdbf6c7b62bd4d38c923
+  React-jsiexecutor: 51f372998e0303585cb0317232b938d694663cbd
+  React-jsinspector: 3539ad976d073bfaa8a7d2fa9bef35e70e55033e
+  React-jsinspectortracing: e8dbacaf67c201f23052ca1c2bae2f7b84dec443
+  React-jsitooling: 95a34f41e3c249d42181de13b4f8d854f178ca9f
+  React-jsitracing: 25b029cf5cad488252d46da19dd8c4c134fd5fe4
+  React-logger: 368570a253f00879a1e4fea24ed4047e72e7bbf3
+  React-Mapbuffer: c04fcda1c6281fc0a6824c7dcc1633dd217ac1ec
+  React-microtasksnativemodule: ca2804a25fdcefffa0aa942aa23ab53b99614a34
+  react-native-advanced-input-mask: 53895636a07455eb65f843a84844f17a55c2ab21
+  react-native-keyboard-controller: 90a30b83295efbb48de9f4fcc905b3f72bbd93a8
+  react-native-safe-area-context: 00d03dc688ba86664be66f9e3f203fc7d747d899
+  React-NativeModulesApple: 452b86b29fae99ed0a4015dca3ad9cd222f88abf
   React-oscompat: ef5df1c734f19b8003e149317d041b8ce1f7d29c
-  React-perflogger: 9a151e0b4c933c9205fd648c246506a83f31395d
-  React-performancetimeline: 5b0dfc0acba29ea0269ddb34cd6dd59d3b8a1c66
+  React-perflogger: 6fd2f6811533e9c19a61e855c3033eecbf4ad2a0
+  React-performancetimeline: abf31259d794c9274b3ea19c5016186925eec6c4
   React-RCTActionSheet: a499b0d6d9793886b67ba3e16046a3fef2cdbbc3
-  React-RCTAnimation: cc64adc259aabc3354b73065e2231d796dfce576
-  React-RCTAppDelegate: 9d523da768f1c9e84c5f3b7e3624d097dfb0e16b
-  React-RCTBlob: e727f53eeefded7e6432eb76bd22b57bc880e5d1
-  React-RCTFabric: 58590aa4fdb4ad546c06a7449b486cf6844e991f
-  React-RCTFBReactNativeSpec: 9064c63d99e467a3893e328ba3612745c3c3a338
-  React-RCTImage: 7159cbdbb18a09d97ba1a611416eced75b3ccb29
-  React-RCTLinking: 46293afdb859bccc63e1d3dedc6901a3c04ef360
-  React-RCTNetwork: 4a6cd18f5bcd0363657789c64043123a896b1170
-  React-RCTRuntime: 5ab904fd749aa52f267ef771d265612582a17880
-  React-RCTSettings: 61e361dc85136d1cb0e148b7541993d2ee950ea7
-  React-RCTText: abd1e196c3167175e6baef18199c6d9d8ac54b4e
-  React-RCTVibration: 490e0dcb01a3fe4a0dfb7bc51ad5856d8b84f343
+  React-RCTAnimation: 2595dcb10a82216a511b54742f8c28d793852ac6
+  React-RCTAppDelegate: f03604b70f57c9469a84a159d8abecf793a5bcff
+  React-RCTBlob: e00f9b4e2f151938f4d9864cf33ebf24ac03328a
+  React-RCTFabric: 3945d116fd271598db262d4e6ed5691d431ed9e8
+  React-RCTFBReactNativeSpec: 0f4d4f0da938101f2ca9d5333a8f46e527ad2819
+  React-RCTImage: dac5e9f8ec476aefe6e60ee640ebc1dfaf1a4dbe
+  React-RCTLinking: 494b785a40d952a1dfbe712f43214376e5f0e408
+  React-RCTNetwork: b3d7c30cd21793e268db107dd0980cb61b3c1c44
+  React-RCTRuntime: a8ff419d437228e7b8a793b14f9d711e1cbb82af
+  React-RCTSettings: a060c7e381a3896104761b8eed7e284d95e37df3
+  React-RCTText: 4f272b72dbb61f390d8c8274528f9fdbff983806
+  React-RCTVibration: 0e5326220719aca12473d703aa46693e3b4ce67a
   React-rendererconsistency: 351fdbc5c1fe4da24243d939094a80f0e149c7a1
-  React-renderercss: 3438814bee838ae7840a633ab085ac81699fd5cf
-  React-rendererdebug: 0ac2b9419ad6f88444f066d4b476180af311fb1e
+  React-renderercss: d333f2ada83969591100d91ec6b23ca2e17e1507
+  React-rendererdebug: 039e5949b72ba63c703de020701e3fd152434c61
   React-rncore: 57ed480649bb678d8bdc386d20fee8bf2b0c307c
-  React-RuntimeApple: 8b7a9788f31548298ba1990620fe06b40de65ad7
-  React-RuntimeCore: e03d96fbd57ce69fd9bca8c925942194a5126dbc
+  React-RuntimeApple: 344a5e1105256000afabaa8df12c3e4cab880340
+  React-RuntimeCore: 0e48fb5e5160acc0334c7a723a42d42cef4b58b6
   React-runtimeexecutor: d60846710facedd1edb70c08b738119b3ee2c6c2
-  React-RuntimeHermes: aab794755d9f6efd249b61f3af4417296904e3ba
-  React-runtimescheduler: c3cd124fa5db7c37f601ee49ca0d97019acd8788
+  React-RuntimeHermes: 064286a03871d932c99738e0f8ef854962ab4b99
+  React-runtimescheduler: e917ab17ae08c204af1ebf8f669b7e411b0220c8
   React-timing: a90f4654cbda9c628614f9bee68967f1768bd6a5
-  React-utils: a612d50555b6f0f90c74b7d79954019ad47f5de6
-  ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
-  ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
-  ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
-  RNGestureHandler: ebef699ea17e7c0006c1074e1e423ead60ce0121
-  RNReanimated: 4fc5b4df060b256f2a221597c9b394831fa6c7c2
-  RNScreens: 5621e3ad5a329fbd16de683344ac5af4192b40d3
+  React-utils: 51c4e71608b8133fecc9a15801d244ae7bdf3758
+  ReactAppDependencyProvider: d5dcc564f129632276bd3184e60f053fcd574d6b
+  ReactCodegen: fda99a79c866370190e162083a35602fdc314e5d
+  ReactCommon: 4d0da92a5eb8da86c08e3ec34bd23ab439fb2461
+  RNGestureHandler: 5d8431415d4b8518e86e289e9ad5bb9be78f6dba
+  RNReanimated: d782062a7cb969d2142c800ede5d1919503d126f
+  RNScreens: c5c07a86e4088ce92f0d3854082250dfa9c61f75
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 9f110fc4b7aa538663cba3c14cbb1c335f43c13f
+  Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 
 PODFILE CHECKSUM: 89f7de4fdf623410b6e0b594681758116e55bba0
 

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -8,7 +8,7 @@
     "web": "./node_modules/.bin/webpack-dev-server",
     "start": "react-native start",
     "build:android": "cd android && ./gradlew assembleRelease --build-cache",
-    "build:ios": "cd ios && xcodebuild -workspace MaskedTextInputExample.xcworkspace -scheme MaskedTextInputExample -configuration Release -destination 'platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro' -sdk iphonesimulator -derivedDataPath build -UseModernBuildSystem=YES CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ | xcpretty",
+    "build:ios": "cd ios && xcodebuild -workspace MaskedTextInputExample.xcworkspace -scheme MaskedTextInputExample -configuration Release -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro' -sdk iphonesimulator -derivedDataPath build -UseModernBuildSystem=YES CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ | xcpretty",
     "build:web": "./node_modules/.bin/webpack"
   },
   "dependencies": {

--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -54,19 +54,19 @@ class AdvancedTextInputMaskDecoratorView(
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
-    var previousSibling: View? = null
+    var nextSibling: View? = null
     val parent = this.parent
     if (parent is ViewGroup) {
-      for (i in 1 until parent.childCount) {
+      for (i in 0 until parent.childCount) {
         if (parent.getChildAt(i) == this) {
-          previousSibling = parent.getChildAt(i - 1)
+          nextSibling = parent.getChildAt(i + 1)
           break
         }
       }
     }
 
-    if (previousSibling is ReactEditText) {
-      textField = previousSibling
+    if (nextSibling is ReactEditText) {
+      textField = nextSibling
       textField?.let {
         if (customTransformationMethod != null) {
           it.transformationMethod = customTransformationMethod

--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -295,15 +295,19 @@ extension AdvancedTextInputMaskDecoratorView {
   private func findTextField() {
     #if ADVANCE_INPUT_MASK_NEW_ARCH_ENABLED
       if let parent = superview?.superview {
-        for elementIndex in 1 ..< parent.subviews.count where parent.subviews[elementIndex] == superview {
-          textField = findFirstTextField(in: parent.subviews[elementIndex - 1])
+        for elementIndex in 0 ..< parent.subviews.count where parent.subviews[elementIndex] == superview {
+          let nextIndex = elementIndex + 1
+          guard nextIndex < parent.subviews.count else { break }
+          textField = findFirstTextField(in: parent.subviews[nextIndex])
           break
         }
       }
     #else
       if let parent = superview {
-        for elementIndex in 1 ..< parent.subviews.count where parent.subviews[elementIndex] == self {
-          textField = findFirstTextField(in: parent.subviews[elementIndex - 1])
+        for elementIndex in 0 ..< parent.subviews.count where parent.subviews[elementIndex] == self {
+          let nextIndex = elementIndex + 1
+          guard nextIndex < parent.subviews.count else { break }
+          textField = findFirstTextField(in: parent.subviews[nextIndex])
           break
         }
       }

--- a/package/src/native/views/MaskedTextInput/index.tsx
+++ b/package/src/native/views/MaskedTextInput/index.tsx
@@ -111,11 +111,6 @@ const MaskedTextInput = forwardRef<MaskedTextInputRef, MaskedTextInputProps>(
 
     return (
       <>
-        <InputComponent
-          {...rest}
-          ref={inputRef}
-          autoCapitalize={autoCapitalize}
-        />
         <AdvancedTextInputMaskDecoratorViewNativeComponent
           // @ts-expect-error the type is correct
           ref={maskedViewDecoratorRef}
@@ -135,6 +130,11 @@ const MaskedTextInput = forwardRef<MaskedTextInputRef, MaskedTextInputProps>(
           validationRegex={validationRegex}
           value={value}
           onAdvancedMaskTextChange={onAdvancedMaskTextChangeCallback}
+        />
+        <InputComponent
+          {...rest}
+          ref={inputRef}
+          autoCapitalize={autoCapitalize}
         />
       </>
     );


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

In this PR, I moved the decorator view before the TextInput component to fix a problem with setting the delegate.

### Problem: 

react-native-keyboard-controller sets its own delegate, and after hiding the keyboard, it resets the delegate to the initial value. Since my delegate was set after react-native-keyboard-controller's it cleans up and mask doesn't work.

fixes #128

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- moved decorator view before text input

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

iPhone 16 pro simulator

Pixel 3a emulator

## 📸 Screenshots (if appropriate):

### Bug ticket:

https://github.com/user-attachments/assets/537224d7-1376-474d-89e9-d73d257edf52

### new arch:

https://github.com/user-attachments/assets/092c0a3f-def5-4730-9ed0-62b9ff3b198c

### old arch:

https://github.com/user-attachments/assets/ff47fe8d-a785-41bc-add7-c7ea0930cddf


https://github.com/user-attachments/assets/19959951-fbda-43a9-9512-856435cd1f97

<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
