### PR TITLE
fix: restore previous mounting logic

### DIFF
--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -54,19 +54,19 @@ class AdvancedTextInputMaskDecoratorView(
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
 
-    var nextSibling: View? = null
+    var previousSibling: View? = null
     val parent = this.parent
     if (parent is ViewGroup) {
-      for (i in 0 until parent.childCount) {
+      for (i in 1 until parent.childCount) {
         if (parent.getChildAt(i) == this) {
-          nextSibling = parent.getChildAt(i + 1)
+          previousSibling = parent.getChildAt(i - 1)
           break
         }
       }
     }
 
-    if (nextSibling is ReactEditText) {
-      textField = nextSibling
+    if (previousSibling is ReactEditText) {
+      textField = previousSibling
       textField?.let {
         if (customTransformationMethod != null) {
           it.transformationMethod = customTransformationMethod

--- a/package/ios/AdvancedTextInputMaskDecoratorView.swift
+++ b/package/ios/AdvancedTextInputMaskDecoratorView.swift
@@ -298,19 +298,15 @@ extension AdvancedTextInputMaskDecoratorView {
   private func findTextField() {
     #if ADVANCE_INPUT_MASK_NEW_ARCH_ENABLED
       if let parent = superview?.superview {
-        for elementIndex in 0 ..< parent.subviews.count where parent.subviews[elementIndex] == superview {
-          let nextIndex = elementIndex + 1
-          guard nextIndex < parent.subviews.count else { break }
-          textField = findFirstTextField(in: parent.subviews[nextIndex])
+        for elementIndex in 1 ..< parent.subviews.count where parent.subviews[elementIndex] == superview {
+          textField = findFirstTextField(in: parent.subviews[elementIndex - 1])
           break
         }
       }
     #else
       if let parent = superview {
-        for elementIndex in 0 ..< parent.subviews.count where parent.subviews[elementIndex] == self {
-          let nextIndex = elementIndex + 1
-          guard nextIndex < parent.subviews.count else { break }
-          textField = findFirstTextField(in: parent.subviews[nextIndex])
+        for elementIndex in 1 ..< parent.subviews.count where parent.subviews[elementIndex] == self {
+          textField = findFirstTextField(in: parent.subviews[elementIndex - 1])
           break
         }
       }

--- a/package/src/native/views/MaskedTextInput/index.tsx
+++ b/package/src/native/views/MaskedTextInput/index.tsx
@@ -112,6 +112,11 @@ const MaskedTextInput = forwardRef<MaskedTextInputRef, MaskedTextInputProps>(
 
     return (
       <>
+        <InputComponent
+          {...rest}
+          ref={inputRef}
+          autoCapitalize={autoCapitalize}
+        />
         <AdvancedTextInputMaskDecoratorViewNativeComponent
           // @ts-expect-error the type is correct
           ref={maskedViewDecoratorRef}
@@ -131,11 +136,6 @@ const MaskedTextInput = forwardRef<MaskedTextInputRef, MaskedTextInputProps>(
           validationRegex={validationRegex}
           value={value}
           onAdvancedMaskTextChange={onAdvancedMaskTextChangeCallback}
-        />
-        <InputComponent
-          {...rest}
-          ref={inputRef}
-          autoCapitalize={autoCapitalize}
         />
       </>
     );


### PR DESCRIPTION
## 📜 Description

These changes have been added to address this problem: #129. However, they have caused numerous other issues, such as #133 and #132.

The problem is that `didMoveToWindow` of the previous view element was called before the text input mount, and we could not find the UITextField in the view hierarchy.

![telegram-cloud-photo-size-2-5460652340060222359-y](https://github.com/user-attachments/assets/ff825033-a0ad-4592-80f6-ba95d672f5a1)

I figured we could ‘delay’ setting the delegate in react-native-keyboard-controller so my library could populate the delegate earlier and fix the bug that was happening in this issue. https://github.com/kirillzyusko/react-native-keyboard-controller/pull/1027

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix mounting issue.

## 📢 Changelog

restore previous mounting logic

## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->


https://github.com/user-attachments/assets/1bcde75d-9ae4-44f9-9359-afb65f910caa


https://github.com/user-attachments/assets/f03200c3-5f82-4f9c-b129-5befd861eda3


## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
