### PR TITLE
feat(android): prevent onChangeText when updating value from JS

### DIFF
--- a/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
+++ b/package/android/src/main/java/com/maskedtextinput/views/AdvancedTextInputMaskDecoratorView.kt
@@ -33,9 +33,12 @@ class AdvancedTextInputMaskDecoratorView(
   private var isInitialMount = true
   private var autocompleteOnFocus = false
   private var validationRegex: Regex? = null
+  private var isSettingFromJS = false
 
   private val valueListener =
     MaskedTextValueListener { complete, extracted, formatted, tailPlaceholder ->
+      if (isSettingFromJS) return@MaskedTextValueListener
+
       val surfaceId = UIManagerHelper.getSurfaceId(context as ReactContext)
       UIManagerHelper.getEventDispatcherForReactTag(context, id)?.dispatchEvent(
         ChangeTextEvent(surfaceId, id, extracted, formatted, tailPlaceholder, complete),
@@ -163,7 +166,9 @@ class AdvancedTextInputMaskDecoratorView(
   fun setValue(value: String?) {
     this.value = value
     if (textField?.text.toString() != value) {
+      isSettingFromJS = true
       value?.let { maskedTextChangeListener?.setText(it, false) }
+      isSettingFromJS = false
     }
   }
 


### PR DESCRIPTION
## 📜 Description

Added a flag isSettingFromJS in AdvancedTextInputMaskDecoratorView to distinguish between text updates coming from JavaScript props (value) and user input. This prevents dispatching onChangeText events when the text is programmatically updated from JS.

## 💡 Motivation and Context

Previously, updating the text via the value prop from JavaScript would trigger onChangeText events in native code, causing unnecessary re-renders and potential loops in React Native. This change ensures that only user-initiated input triggers events, improving performance and correctness.

## 📢 Changelog

### JS

- No changes in JS API, behavior remains the same.

### iOS

- No changes.

### Android

- Added isSettingFromJS flag in AdvancedTextInputMaskDecoratorView.
- Modified valueListener to skip dispatching ChangeTextEvent when isSettingFromJS is true.
- Updated setValue and setText to set the flag during JS-driven updates.

## 🤔 How Has This Been Tested?

- Verified that typing in the input still dispatches onChangeText events correctly.
- Verified that updating the text from JS via value prop does not dispatch onChangeText.
- Manual testing on Android emulator and physical device.
- Confirmed that mask behavior and autocomplete still function as expected.

## 📸 Screenshots (if appropriate):
Before

https://github.com/user-attachments/assets/f4bbad67-ed9a-447a-bcc8-a9a4366b270c


After

https://github.com/user-attachments/assets/21e53833-d422-4c4f-99f9-3301ad9b62a1





## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
