### PR TITLE
Fix can't clear prefilled text

### DIFF
--- a/package/src/web/hooks/useMaskedTextInputListener/index.ts
+++ b/package/src/web/hooks/useMaskedTextInputListener/index.ts
@@ -29,9 +29,9 @@ const useMaskedTextInputListener = ({
   validationRegex,
 }: Props) => {
   const prevDispatchedPayload = useRef<{
-    extracted: string;
-    formatted: string;
-  }>({ extracted: "", formatted: "" });
+    extracted: string | null;
+    formatted: string | null;
+  }>({ extracted: null, formatted: null });
 
   const isInitialMount = useRef(true);
 


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If we have a prefilled text input, and then we select all text and delete, it doesn't work. This can be reproduced on the example app by going to the "Controlled Input" page then select all text and delete.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- Fix can't clear prefilled text


## 🤔 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested this on the example app, specifically on the "Controlled Input" page.
1. Open Controlled Input
2. Select all text from the input
3. Press Delete
4. Verify the text is deleted



## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

Before:

https://github.com/user-attachments/assets/f707e51c-cdc9-4dbe-820f-656d0651feb7

After:

https://github.com/user-attachments/assets/bee05078-b34c-4f53-aaed-c690879ab0ce

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
