### PR TITLE
fix: show soft keyboard on programmatic focus for masked inputs on Android

### DIFF
--- a/packages/react-native-advanced-input-mask/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
+++ b/packages/react-native-advanced-input-mask/android/src/main/java/com/maskedtextinput/listeners/ReactMaskedTextChangeListener.kt
@@ -1,7 +1,9 @@
 package com.maskedtextinput.listeners
 
+import android.content.Context
 import android.text.Editable
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import com.facebook.react.views.textinput.ReactEditText
 import com.redmadrobot.inputmask.MaskedTextChangedListener
 import com.redmadrobot.inputmask.helper.AffinityCalculationStrategy
@@ -79,6 +81,24 @@ class ReactMaskedTextChangeListener(
       this.autocomplete = prevAutocomplete
     }
     focusChangeListener.onFocusChange(view, hasFocus)
+    if (hasFocus) {
+      requestShowSoftInput()
+    }
+  }
+
+  // ReactEditText's programmatic focus (autoFocus/ref.focus()) requests the IME synchronously
+  // right after requestFocus, but with the mask listeners installed that request is dropped
+  // before the IME session starts, so the keyboard never appears (a tap still works via the
+  // framework's touch handler). Re-request on the next frame. No-op when the keyboard is
+  // already visible (e.g. focus by tap).
+  fun requestShowSoftInput() {
+    if (!field.isInTouchMode || !field.showSoftInputOnFocus) return
+    field.post {
+      if (field.hasFocus()) {
+        val imm = field.context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        imm?.showSoftInput(field, 0)
+      }
+    }
   }
 
   companion object {
@@ -114,6 +134,13 @@ class ReactMaskedTextChangeListener(
         )
       field.addTextChangedListener(listener)
       field.onFocusChangeListener = listener
+
+      // autoFocus fires before this listener is installed (the EditText attaches to the
+      // window before the decorator does), so onFocusChange never sees the mount-time
+      // focus - re-request the IME here when the field is already focused.
+      if (field.hasFocus()) {
+        listener.requestShowSoftInput()
+      }
 
       return listener
     }


### PR DESCRIPTION
## Summary

On Android (tested on the New Architecture, RN 0.86), calling `ref.focus()` on a `MaskedTextInput` — or mounting one with `autoFocus` — gives the field focus (blinking caret) but never raises the soft keyboard. Tapping the field works, and plain unmasked `TextInput`s are unaffected.

## Root cause

`ReactEditText.requestFocusProgrammatically` calls `showSoftInput` synchronously right after `requestFocus`. With the mask listeners installed on the field, that request is dropped before the IME session for the field starts, so the keyboard never appears. A tap works because the framework's touch handler opens the IME itself, after input has started.

There are two paths that miss the keyboard:

1. **Later programmatic focus** (`ref.focus()`): the field gains focus, `onFocusChange` fires, but nothing re-requests the IME.
2. **Mount-time `autoFocus`**: the `ReactEditText` attaches to the window (and RN focuses it) *before* the decorator view attaches and installs the mask listener — so the listener's `onFocusChange` never even sees the mount-time focus.

## Fix

Add `requestShowSoftInput()` to `ReactMaskedTextChangeListener`, which posts a `showSoftInput` on the next frame (by which time the IME session exists). It is:

- gated on `field.isInTouchMode && field.showSoftInputOnFocus`, matching `ReactEditText`'s own keyboard-show conditions (so `showSoftInputOnFocus={false}` fields and non-touch contexts behave unchanged),
- re-checked against `field.hasFocus()` inside the post,
- a no-op when the keyboard is already visible (e.g. focus by tap).

It's called from `onFocusChange` on focus gain (path 1) and from `installOn` when the field is already focused at install time (path 2).

## Testing

Verified on an Android emulator (New Arch, RN 0.86) with a masked phone-number field: before the change, mount-time `autoFocus` and `ref.focus()` left the field focused with no keyboard (`dumpsys input_method` → `mInputShown=false`); with the change, the keyboard is raised in both cases (`mInputShown=true`), and tap-to-focus behavior is unchanged. iOS is unaffected.