### PR TITLE
fix(ios): drop unused `RCTBaseTextInputView.h` import (build break on react-native 0.87)

### DIFF
--- a/packages/react-native-advanced-input-mask/ios/MaskedTextInput-Bridging-Header.h
+++ b/packages/react-native-advanced-input-mask/ios/MaskedTextInput-Bridging-Header.h
@@ -1,5 +1,4 @@
 #import <React/RCTBackedTextInputDelegateAdapter.h>
-#import <React/RCTBaseTextInputView.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>


### PR DESCRIPTION
## 📜 Description

Removes the `#import <React/RCTBaseTextInputView.h>` line from the iOS bridging header.

## 💡 Motivation and Context

React Native 0.87 removed the legacy bridge, and `RCTBaseTextInputView.h` went with it, so the iOS build now fails on the bridging header. Nothing in the package references that class; the import was already unused, it just didn't hurt until the header disappeared.

## 📢 Changelog

### iOS

- removed an unused `RCTBaseTextInputView.h` import that breaks the build on react-native 0.87

## 🤔 How Has This Been Tested?

We've been running this removal as a package patch on 1.4.6 since upgrading our app to react-native 0.87.0 (new architecture). The app builds and our masked inputs keep working. Verified on the iOS simulator.

## 📝 Checklist

- [ ] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed (no API change, one dead include removed)
